### PR TITLE
HCK-8631: adjust union behavior

### DIFF
--- a/properties_pane/defaultData.json
+++ b/properties_pane/defaultData.json
@@ -295,7 +295,14 @@
 	},
 	"subschema": {},
 	"arrayItem": {},
-	"choice": {},
+	"choice": {
+		"hackoladeMeta": {
+			"resetInsteadOfDelete": true,
+			"disableAdd": false,
+			"disableAppend": true,
+			"disableReference": true
+		}
+	},
 	"relationship": {},
 	"user": {},
 	"view": {

--- a/snippets/union.json
+++ b/snippets/union.json
@@ -6,9 +6,7 @@
 		{
 			"type": "choice",
 			"choice": "oneOf",
-			"hackoladeMeta": {
-				"resetInsteadOfDelete": true
-			}
+			"createDefaultSubschemas": false
 		}
 	]
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8631" title="HCK-8631" target="_blank"><img alt="Bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-8631</a>  [GraphQL] Adjust oneOf choice functionality used by union
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->

Sub-task: HCK-8633

## Content

Adjust items in the context menu enabled `oneOf` choice used for unions.

...