### PR TITLE
Fix object type config

### DIFF
--- a/properties_pane/defaultData.json
+++ b/properties_pane/defaultData.json
@@ -242,37 +242,6 @@
 				}
 			]
 		},
-		"structureType": {
-			"valueDependencies": [
-				{
-					"value": true,
-					"dependency": [
-						{
-							"key": "subtype",
-							"value": "anyParameter"
-						},
-						{
-							"type": "and",
-							"values": [
-								{
-									"key": "childType",
-									"value": "object"
-								},
-								{
-									"type": "not",
-									"values": [
-										{
-											"key": "subtype",
-											"value": "schema"
-										}
-									]
-								}
-							]
-						}
-					]
-				}
-			]
-		},
 		"schemeType": "apiKey",
 		"required": {
 			"valueDependencies": [


### PR DESCRIPTION
## Technical details

This PR removes the "structure type" property default data config copied from OpenAPI, as it is not needed in GraphQL, and breaks the _object_ type's behavior.

...