### PR TITLE
HCK-8877: add directives property

### DIFF
--- a/properties_pane/container_level/containerLevelConfig.json
+++ b/properties_pane/container_level/containerLevelConfig.json
@@ -170,59 +170,11 @@ making sure that you maintain a proper JSON format.
 			},
 			{
 				"propertyName": "Directives",
-				"propertyKeyword": "directives",
-				"propertyTooltip": "",
-				"propertyType": "group",
-				"structure": [
-					{
-						"propertyName": "Directive",
-						"propertyKeyword": "directive",
-						"propertyTooltip": "",
-						"propertyType": "text"
-					},
-					{
-						"propertyName": "Description",
-						"propertyKeyword": "description",
-						"propertyTooltip": "Popup for multi-line text entry",
-						"propertyType": "details",
-						"template": "textarea"
-					},
-					{
-						"propertyName": "Arguments",
-						"propertyKeyword": "arguments",
-						"propertyTooltip": "Popup for multi-line text entry",
-						"propertyType": "details",
-						"template": "textarea",
-						"markdown": false
-					},
-					{
-						"propertyName": "Applicable elements",
-						"propertyKeyword": "dropdownProp",
-						"propertyTooltip": "Select from list of options",
-						"propertyType": "multipleCheckboxSelect",
-						"options": [
-							"ARGUMENT_DEFINITION",
-							"ENUM",
-							"ENUM_VALUE",
-							"FIELD",
-							"FIELD_DEFINITION",
-							"FRAGMENT_DEFINITION",
-							"FRAGMENT_SPREAD",
-							"INLINE_FRAGMENT",
-							"INPUT_FIELD_DEFINITION",
-							"INPUT_OBJECT",
-							"INTERFACE",
-							"MUTATION",
-							"OBJECT",
-							"QUERY",
-							"SCALAR",
-							"SCHEMA",
-							"SUBSCRIPTION",
-							"UNION",
-							"VARIABLE_DEFINITION"
-						]
-					}
-				]
+				"propertyKeyword": "directive",
+				"propertyTooltip": "Schema directives",
+				"propertyType": "details",
+				"template": "textarea",
+				"markdown": false
 			},
 			{
 				"propertyName": "Comments",

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -406,7 +406,21 @@ making sure that you maintain a proper JSON format.
 			},
 			"comments"
 		],
-		"enum": ["name", "enum", "description", "comments"],
+		"enum": [
+			"name",
+			"enum",
+			"description",
+			"required",
+			{
+				"propertyName": "Directives",
+				"propertyKeyword": "directive",
+				"propertyTooltip": "Enum directives",
+				"propertyType": "details",
+				"template": "textarea",
+				"markdown": false
+			},
+			"comments"
+		],
 		"object": [
 			"name",
 			"description",

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -393,7 +393,19 @@ making sure that you maintain a proper JSON format.
 				"hidden": true
 			}
 		],
-		"scalar": ["name", "description", "comments"],
+		"scalar": [
+			"name",
+			"description",
+			{
+				"propertyName": "Directives",
+				"propertyKeyword": "directive",
+				"propertyTooltip": "Scalar directives",
+				"propertyType": "details",
+				"template": "textarea",
+				"markdown": false
+			},
+			"comments"
+		],
 		"enum": ["name", "enum", "description", "comments"],
 		"object": ["name", "description", "required", "minProperties", "maxProperties", "comments"],
 		"interface": ["name", "description", "required", "minProperties", "maxProperties", "comments"],

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -467,7 +467,20 @@ making sure that you maintain a proper JSON format.
 			},
 			"comments"
 		],
-		"input": ["name", "description", "required", "comments"],
+		"input": [
+			"name",
+			"description",
+			"required",
+			{
+				"propertyName": "Directives",
+				"propertyKeyword": "directive",
+				"propertyTooltip": "Input directives",
+				"propertyType": "details",
+				"template": "textarea",
+				"markdown": false
+			},
+			"comments"
+		],
 		"directive": [
 			"name",
 			"description",

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -423,7 +423,22 @@ making sure that you maintain a proper JSON format.
 			"maxProperties",
 			"comments"
 		],
-		"interface": ["name", "description", "required", "minProperties", "maxProperties", "comments"],
+		"interface": [
+			"name",
+			"description",
+			"required",
+			{
+				"propertyName": "Directives",
+				"propertyKeyword": "directive",
+				"propertyTooltip": "Interface directives",
+				"propertyType": "details",
+				"template": "textarea",
+				"markdown": false
+			},
+			"minProperties",
+			"maxProperties",
+			"comments"
+		],
 		"union": ["name", "description", "required", "comments"],
 		"input": ["name", "description", "required", "comments"],
 		"directive": [

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -439,7 +439,20 @@ making sure that you maintain a proper JSON format.
 			"maxProperties",
 			"comments"
 		],
-		"union": ["name", "description", "required", "comments"],
+		"union": [
+			"name",
+			"description",
+			"required",
+			{
+				"propertyName": "Directives",
+				"propertyKeyword": "directive",
+				"propertyTooltip": "Union directives",
+				"propertyType": "details",
+				"template": "textarea",
+				"markdown": false
+			},
+			"comments"
+		],
 		"input": ["name", "description", "required", "comments"],
 		"directive": [
 			"name",

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -143,9 +143,9 @@ making sure that you maintain a proper JSON format.
 				"markdown": false
 			},
 			{
-				"propertyName": "Directive",
+				"propertyName": "Directives",
 				"propertyKeyword": "directive",
-				"propertyTooltip": "Popup for multi-line text entry",
+				"propertyTooltip": "Field directives",
 				"propertyType": "details",
 				"template": "textarea",
 				"markdown": false
@@ -186,9 +186,9 @@ making sure that you maintain a proper JSON format.
 				"markdown": false
 			},
 			{
-				"propertyName": "Directive",
+				"propertyName": "Directives",
 				"propertyKeyword": "directive",
-				"propertyTooltip": "Popup for multi-line text entry",
+				"propertyTooltip": "Field directives",
 				"propertyType": "details",
 				"template": "textarea",
 				"markdown": false
@@ -231,9 +231,9 @@ making sure that you maintain a proper JSON format.
 				"markdown": false
 			},
 			{
-				"propertyName": "Directive",
+				"propertyName": "Directives",
 				"propertyKeyword": "directive",
-				"propertyTooltip": "Popup for multi-line text entry",
+				"propertyTooltip": "Field directives",
 				"propertyType": "details",
 				"template": "textarea",
 				"markdown": false
@@ -274,9 +274,9 @@ making sure that you maintain a proper JSON format.
 				"markdown": false
 			},
 			{
-				"propertyName": "Directive",
+				"propertyName": "Directives",
 				"propertyKeyword": "directive",
-				"propertyTooltip": "Popup for multi-line text entry",
+				"propertyTooltip": "Field directives",
 				"propertyType": "details",
 				"template": "textarea",
 				"markdown": false
@@ -317,9 +317,9 @@ making sure that you maintain a proper JSON format.
 				"markdown": false
 			},
 			{
-				"propertyName": "Directive",
+				"propertyName": "Directives",
 				"propertyKeyword": "directive",
-				"propertyTooltip": "Popup for multi-line text entry",
+				"propertyTooltip": "Field directives",
 				"propertyType": "details",
 				"template": "textarea",
 				"markdown": false

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -407,7 +407,22 @@ making sure that you maintain a proper JSON format.
 			"comments"
 		],
 		"enum": ["name", "enum", "description", "comments"],
-		"object": ["name", "description", "required", "minProperties", "maxProperties", "comments"],
+		"object": [
+			"name",
+			"description",
+			"required",
+			{
+				"propertyName": "Directives",
+				"propertyKeyword": "directive",
+				"propertyTooltip": "Object directives",
+				"propertyType": "details",
+				"template": "textarea",
+				"markdown": false
+			},
+			"minProperties",
+			"maxProperties",
+			"comments"
+		],
 		"interface": ["name", "description", "required", "minProperties", "maxProperties", "comments"],
 		"union": ["name", "description", "required", "comments"],
 		"input": ["name", "description", "required", "comments"],


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8877" title="HCK-8877" target="_blank"><img alt="Task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />HCK-8877</a>  Assign directive as free text to all elements that can have a directive
  </td></table>
  <br />
 
Sub-task: HCK-8952

<!--jira-description-action-hidden-marker-end-->

## Technical details

This PR adds the "Directives" property to all applicable locations as specified in the [GraphQL spec](https://spec.graphql.org/October2021/#TypeSystemDirectiveLocation), except for ENUM_VALUE, which will be implemented later.
...