### PR TITLE
HCK-8882: allow referencing type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,9 @@
             },
             "definitionSources": {
                 "multipleSources": true
-            }
+            },
+            "disablePickFromFieldList": true,
+            "hideDisabledAttributeTypes": true
         }
     },
     "description": "Hackolade plugin for GraphQL",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
                 }
             },
             "disableDefinitions": {
-                "internal": true
+                "internal": true,
+                "external": true
             },
             "disableRelationships": false,
             "relationships": {

--- a/types/input.json
+++ b/types/input.json
@@ -19,7 +19,20 @@
 	},
 	"subtypes": {
 		"snippetChildrenOnly": {
-			"childValueType": ["String", "ID", "Int", "Float", "Boolean", "List", "input", "enum", "scalar"]
+			"childValueType": [
+				"String", 
+				"ID", 
+				"Int", 
+				"Float", 
+				"Boolean", 
+				"List", 
+				"reference"
+			],
+			"childReferenceValueType": [
+				"input",
+				"enum",
+				"scalar"
+			]
 		}
 	},
 	"dependency": {

--- a/types/interface.json
+++ b/types/interface.json
@@ -26,6 +26,9 @@
 				"Float",
 				"Boolean",
 				"List",
+				"reference"
+			],
+			"childReferenceValueType": [
 				"object",
 				"interface",
 				"union",

--- a/types/object.json
+++ b/types/object.json
@@ -26,6 +26,9 @@
 				"Float",
 				"Boolean",
 				"List",
+				"reference"
+			],
+			"childReferenceValueType": [
 				"object",
 				"interface",
 				"union",

--- a/types/union.json
+++ b/types/union.json
@@ -21,6 +21,9 @@
 	"subtypes": {
 		"snippetChildrenOnly": {
 			"childValueType": [
+				"reference"
+			],
+			"childReferenceValueType": [
 				"object"
 			]
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8882" title="HCK-8882" target="_blank"><img alt="Task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />HCK-8882</a>  Only allow built-in scalar and reference as field to a type
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR introduces new type configurations to restrict field additions to built-in scalars (String, ID, Int, Float, Boolean) and the List type. All other types must be referenced instead. To achieve this, a new configuration key `childReferenceValueType` has been added.