### PR TITLE
HCK-5119: finish renaming object type

### DIFF
--- a/properties_pane/defaultData.json
+++ b/properties_pane/defaultData.json
@@ -24,9 +24,8 @@
 		"collectionName": "Response",
 		"entityType": "response",
 		"snippet": "responseStructure",
-		"subtype": "response",
 		"isActivated": true,
-		"childType": "type"
+		"childType": "object"
 	},
 	"field": {
 		"hackoladeMeta": {
@@ -167,10 +166,10 @@
 					}
 				},
 				{
-					"value": "NewType",
+					"value": "NewObject",
 					"dependency": {
 						"key": "childType",
-						"value": "type"
+						"value": "object"
 					}
 				},
 				{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-5119" title="HCK-5119" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-5119</a>  Configure output (child) ERD entity
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Follow-up for https://github.com/hackolade/GraphQL/pull/11 where the `type` was renamed to object.
There were two missed points for the response entity, which is the `object` type.
... 