### PR TITLE
HCK-8881: fix resetting union choice

### DIFF
--- a/properties_pane/defaultData.json
+++ b/properties_pane/defaultData.json
@@ -270,7 +270,8 @@
 			"resetInsteadOfDelete": true,
 			"disableAdd": false,
 			"disableAppend": true,
-			"disableReference": true
+			"disableReference": true,
+			"createDefaultSubschemas": false
 		}
 	},
 	"relationship": {},

--- a/snippets/union.json
+++ b/snippets/union.json
@@ -5,8 +5,7 @@
 	"properties": [
 		{
 			"type": "choice",
-			"choice": "oneOf",
-			"createDefaultSubschemas": false
+			"choice": "oneOf"
 		}
 	]
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8881" title="HCK-8881" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-8881</a>  Reset oneOf node should not add 2 empty subschema node
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR fixes the resetting of the _oneOf_ choice used by a union.
The `createDefaultSubschemas` option that is used to determine if the default subschemas should be created for a choice was moved to the default data config.