### PR TITLE
HCK-9085: restrict List type children

### DIFF
--- a/properties_pane/defaultData.json
+++ b/properties_pane/defaultData.json
@@ -28,6 +28,37 @@
 		"childType": "object"
 	},
 	"field": {
+		"subtype": {
+			"valueDependencies": [
+				{
+					"value": "inputList",
+					"dependency": {
+						"type": "or",
+						"values": [
+							{
+								"type": "and",
+								"values": [
+									{
+										"key": "childType",
+										"value": "List"
+									},
+									{
+										"level": "parent",
+										"key": "childType",
+										"value": "input"
+									}
+								]
+							},
+							{
+								"level": "parent",
+								"key": "subtype",
+								"value": "inputList"
+							}
+						]
+					}
+				}
+			]
+		},
 		"hackoladeMeta": {
 			"valueDependencies": [
 				{
@@ -38,113 +69,6 @@
 						"key": "childType",
 						"value": "type"
 					}
-				},
-				{
-					"value": {
-						"disableAppend": true,
-						"disableDelete": true,
-						"disableAdd": true,
-						"disableReference": true
-					},
-					"dependency": {
-						"type": "and",
-						"values": [
-							{
-								"key": "childType",
-								"value": "expression"
-							},
-							{
-								"level": "parent",
-								"key": "childType",
-								"value": "link"
-							}
-						]
-					}
-				},
-				{
-					"value": {
-						"disableAppend": true,
-						"disableReference": false
-					},
-					"dependency": {
-						"level": "parent",
-						"key": "subtype",
-						"value": "structuralSchema"
-					}
-				},
-				{
-					"value": {
-						"disableAdd": false,
-						"disableDelete": false,
-						"disableAppend": true,
-						"resetInsteadOfDelete": true,
-						"disableChoices": true
-					},
-					"dependency": [
-						{
-							"key": "subtype",
-							"value": "anyParameter"
-						}
-					]
-				},
-				{
-					"value": {
-						"disableDelete": false,
-						"disableAppend": false,
-						"resetInsteadOfDelete": false,
-						"displayNameFromField": false
-					},
-					"dependency": {
-						"level": "parent",
-						"key": "childType",
-						"value": "type"
-					}
-				},
-				{
-					"value": {
-						"disableReference": true
-					},
-					"dependency": {
-						"key": "childType",
-						"value": "media"
-					}
-				},
-				{
-					"value": {
-						"disableAppend": false,
-						"disableDelete": false,
-						"disableReference": false,
-						"resetInsteadOfDelete": false
-					},
-					"dependency": {
-						"level": "parent",
-						"key": "subtype",
-						"value": "schema"
-					}
-				},
-				{
-					"value": {
-						"disableAppend": true,
-						"disableReference": true
-					},
-					"dependency": [
-						{
-							"type": "and",
-							"values": [
-								{
-									"key": "childType",
-									"value": "object"
-								},
-								{
-									"type": "not",
-									"values": {
-										"key": "subtype",
-										"value": "schema"
-									}
-								}
-							]
-						}
-					]
 				}
 			]
 		},
@@ -199,63 +123,10 @@
 						"key": "childType",
 						"value": "directive"
 					}
-				},
-
-				{
-					"value": "application/json",
-					"dependency": {
-						"level": "parent",
-						"key": "subtype",
-						"value": "media"
-					}
-				},
-				{
-					"value": "response",
-					"dependency": {
-						"level": "parent",
-						"key": "subtype",
-						"value": "response"
-					}
-				},
-				{
-					"value": "parameterName",
-					"dependency": {
-						"level": "parent",
-						"key": "subtype",
-						"value": "anyParameter"
-					}
-				},
-				{
-					"value": "schema",
-					"dependency": {
-						"level": "parent",
-						"key": "subtype",
-						"value": "structuralSchema"
-					}
-				},
-				{
-					"value": "schema",
-					"dependency": {
-						"level": "parent",
-						"key": "type",
-						"value": "subschema"
-					}
 				}
 			]
 		},
-		"schemeType": "apiKey",
-		"required": {
-			"valueDependencies": [
-				{
-					"value": true,
-					"dependency": {
-						"key": "childType",
-						"value": "parameter (path)"
-					}
-				}
-			],
-			"value": false
-		}
+		"schemeType": "apiKey"
 	},
 	"patternField": {
 		"name": "^New Pattern Field$"

--- a/types/List.json
+++ b/types/List.json
@@ -6,12 +6,48 @@
 	"useSample": true,
 	"hiddenOnEntity": "view",
 	"defaultValues": {
-		"subtype": "list<str>",
 		"properties": [],
 		"primaryKey": false,
 		"additionalItems": true,
 		"minItems": "",
 		"maxItems": "",
-		"uniqueItems": false
+		"uniqueItems": false,
+		"subtype": "outputList"
+	},
+	"subtypes": {
+		"outputList": {
+			"childValueType": [
+				"String", 
+				"ID", 
+				"Int", 
+				"Float", 
+				"Boolean", 
+				"List", 
+				"reference"
+			],
+			"childReferenceValueType": [
+				"object",
+				"interface",
+				"union",
+				"enum",
+				"scalar"
+			]
+		},
+		"inputList": {
+			"childValueType": [
+				"String", 
+				"ID", 
+				"Int", 
+				"Float", 
+				"Boolean", 
+				"List", 
+				"reference"
+			],
+			"childReferenceValueType": [
+				"input",
+				"enum",
+				"scalar"
+			]
+		}
 	}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9085" title="HCK-9085" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9085</a>  [GraphQL] Incorrect datatypes are available for select as List child values
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR enforces constraints on the _list_ field type to ensure it only accepts appropriate child types based on its parent type.

Changes Made:
1. Input Parent Type:
- Allowed Child Types:
   - Built-in Scalars (String, Int, Float, Boolean, ID)
   - Lists
   - References to Input Types, Enums, Custom Scalars
 
2. Output Parent Types:
- Allowed Child Types:
   - Built-in Scalars
   - Lists
   - References to all other types except Input Types...