### PR TITLE
HCK-9099: allow output types fields as entity children

### DIFF
--- a/properties_pane/defaultData.json
+++ b/properties_pane/defaultData.json
@@ -15,10 +15,9 @@
 	},
 	"collection": {
 		"collectionName": "newOperation",
-		"entityType": "request",
 		"operationType": "Query",
 		"isActivated": true,
-		"childType": "input"
+		"childType": "object"
 	},
 	"nestedCollection": {
 		"collectionName": "Response",

--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -124,11 +124,7 @@ making sure that you maintain a proper JSON format.
 			{
 				"propertyName": "Operation name",
 				"propertyKeyword": "collectionName",
-				"propertyType": "text",
-				"dependency": {
-					"key": "entityType",
-					"value": "request"
-				}
+				"propertyType": "text"
 			},
 			{
 				"propertyName": "Response name",
@@ -153,11 +149,7 @@ making sure that you maintain a proper JSON format.
 					"Query",
 					"Mutation",
 					"Subscription"
-				],
-				"dependency": {
-					"key": "entityType",
-					"value": "request"
-				}
+				]
 			},
 			{
 				"propertyKeyword": "additionalProperties",
@@ -186,25 +178,6 @@ making sure that you maintain a proper JSON format.
 				"propertyType": "details",
 				"template": "textarea",
 				"markdown": false
-			},
-			{
-				"propertyName": "schema",
-				"propertyKeyword": "pathItemSchema",
-				"propertyType": "fieldList",
-				"template": "orderedList",
-				"dependency": {
-					"type": "and",
-					"values": [
-						{
-							"key": "collectionName",
-							"value": "$ref"
-						},
-						{
-							"key": "entityType",
-							"value": "request"
-						}
-					]
-				}
 			},
 			{
 				"propertyName": "Comments",

--- a/types/input.json
+++ b/types/input.json
@@ -34,15 +34,5 @@
 				"scalar"
 			]
 		}
-	},
-	"dependency": {
-		"type": "not",
-		"values": [
-			{
-				"level": "root",
-				"key": "entityType",
-				"value": "response"
-			}
-		]
 	}
 }

--- a/types/interface.json
+++ b/types/interface.json
@@ -36,15 +36,5 @@
 				"scalar"
 			]
 		}
-	},
-	"dependency": {
-		"type": "not",
-		"values": [
-			{
-				"level": "root",
-				"key": "entityType",
-				"value": "request"
-			}
-		]
 	}
 }

--- a/types/type.json
+++ b/types/type.json
@@ -130,15 +130,5 @@
 				"parameter (cookie)"
 			]
 		}
-	},
-	"dependency": {
-		"type": "not",
-		"values": [
-			{
-				"level": "root",
-				"key": "entityType",
-				"value": "request"
-			}
-		]
 	}
 }

--- a/types/union.json
+++ b/types/union.json
@@ -27,15 +27,5 @@
 				"object"
 			]
 		}
-	},
-	"dependency": {
-		"type": "not",
-		"values": [
-			{
-				"level": "root",
-				"key": "entityType",
-				"value": "request"
-			}
-		]
 	}
 }


### PR DESCRIPTION
## Content

According to the new approach for ERD, we should be able to model graph root types (Query, Mutation, Subscription).
Every ERD entity should allow only output type fields (all except the Input type).
...