### PR TITLE
HCK-9199: enrich Enum values with description and directives

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -640,7 +640,61 @@ making sure that you maintain a proper JSON format.
 		],
 		"enum": [
 			"name",
-			"enum",
+			{
+				"propertyName": "Enum values",
+				"propertyKeyword": "enumValues",
+				"propertyTooltip": "Enum values",
+				"propertyType": "group",
+				"structure": [
+					{
+						"propertyName": "Value",
+						"propertyKeyword": "value",
+						"propertyType": "text"
+					},
+					{
+						"propertyName": "Description",
+						"propertyKeyword": "description",
+						"propertyType": "text"
+					},
+					{
+						"propertyName": "Directives",
+						"propertyKeyword": "typeDirectives",
+						"propertyTooltip": "Enum directives",
+						"propertyType": "group",
+						"structure": [
+							{
+								"propertyName": "Directive format",
+								"propertyKeyword": "directiveFormat",
+								"propertyTooltip": "Select directive format",
+								"propertyType": "select",
+								"options": [
+									"Raw"
+								],
+								"defaultValue": "Raw",
+								"helpInfo": {
+									"type": "modal",
+									"title": "PROPERTIES_PANE___DIRECTIVES_INFO_MODAL_TITLE",
+									"content": "PROPERTIES_PANE___DIRECTIVES_INFO_MODAL_BODY",
+									"featureNameForHelp": "GraphQL directives",
+									"buttons": ["contactSupport", "ok"]
+								}
+							},
+							{
+								"propertyName": "Raw directive",
+								"propertyKeyword": "rawDirective",
+								"propertyTooltip": "Enter raw directive",
+								"propertyType": "details",
+								"template": "textarea",
+								"markdown": false,
+								"dependency": {
+									"key": "directiveFormat",
+									"value": "Raw"
+								}
+							}
+						]
+					}
+				]
+			},
 			"description",
 			{
 				"propertyName": "Required",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9199" title="HCK-9199" target="_blank"><img alt="Task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium" />HCK-9199</a>  Enriched Enum values with description and directive
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content
sub-task: HCK-9207

This PR enriches Enum type values with _description_ and _directives_ properties according to GraphQL spec.