### PR TITLE
HCK-9427: add missed parts of Implements config

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1283,7 +1283,9 @@ making sure that you maintain a proper JSON format.
 							"propertyType": "selecthashed",
 							"template": "definitions",
 							"sideEffectActions": {
-								"onSelect": "copySelectedItemChildAttributes"
+								"onSelect": {
+									"action": "copySelectedItemChildAttributes"
+								}
 							}
 						}
 					],
@@ -1320,9 +1322,26 @@ making sure that you maintain a proper JSON format.
 							"propertyKeyword": "interface",
 							"propertyTooltip": "Select interface",
 							"propertyType": "selecthashed",
-							"template": "definitions"
+							"template": "definitions",
+							"sideEffectActions": {
+								"onSelect": {
+									"action": "copySelectedItemChildAttributes"
+								}
+							}
 						}
-					]
+					],
+					"sideEffectActions": {
+						"onRemove": {
+							"action": "showMessage",
+							"actionConfig": {
+								"type": "modal",
+								"title": "PROPERTIES_PANE___REMOVE_IMPLEMENTED_INTERFACE_WARNING_TITLE",
+								"content": "PROPERTIES_PANE___REMOVE_IMPLEMENTED_INTERFACE_WARNING_BODY",
+								"featureNameForHelp": "Removing of implemented interfaces in GraphQL",
+								"buttons": ["contactSupport", "ok"]
+							}
+						}
+					}
 				}
 			]
 		}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9427" title="HCK-9427" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9427</a>  [GraphQL] No confirmation message on removing added interface to interface in Implements tab
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR is a follow-up for the next PR https://github.com/hackolade/GraphQL/pull/27
It adds missed config parts for the "Implements" of interfaces.