### PR TITLE
HCK-9428: configure implement interfaces select input

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1282,6 +1282,17 @@ making sure that you maintain a proper JSON format.
 							"propertyTooltip": "Select interface",
 							"propertyType": "selecthashed",
 							"template": "definitions",
+							"templateOptions": {
+								"filter": {
+									"condition": {
+										"key": "childType",
+										"value": "interface"
+									},
+									"options": {
+										"useAllDefinitionsAsSource": true
+									}
+								}
+							},
 							"sideEffectActions": {
 								"onSelect": {
 									"action": "copySelectedItemChildAttributes"
@@ -1323,6 +1334,18 @@ making sure that you maintain a proper JSON format.
 							"propertyTooltip": "Select interface",
 							"propertyType": "selecthashed",
 							"template": "definitions",
+							"templateOptions": {
+								"filter": {
+									"condition": {
+										"key": "childType",
+										"value": "interface"
+									},
+									"options": {
+										"filterOutSelf": true,
+										"useAllDefinitionsAsSource": true
+									}
+								}
+							},
 							"sideEffectActions": {
 								"onSelect": {
 									"action": "copySelectedItemChildAttributes"

--- a/snippets/definitions.json
+++ b/snippets/definitions.json
@@ -16,15 +16,15 @@
 		{
 			"name": "Objects",
 			"type": "type",
-			"subtype": "object"
+			"subtype": "object",
+			"hackoladeMeta": {
+				"source": true
+			}
 		},
 		{
 			"name": "Interfaces",
 			"type": "type",
-			"subtype": "interface",
-			"hackoladeMeta": {
-				"source": true // is used by "Implements interfaces" selechashed property, to indicate which definitions to show in interfaces dropdown
-			}
+			"subtype": "interface"
 		},
 		{
 			"name": "Unions",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9428" title="HCK-9428" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9428</a>  [GraphQL] Interfaces: incorrect ability to select interface itself from Implements tab
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR adds a filtering configuration for the "Implements of interfaces" select input.

Changes:
1. Replaces the usage of the `source` flag with explicit filtering using dependency conditions defined in `templateOptions.filter.condition`, as was promised in https://github.com/hackolade/GraphQL/pull/27
2. Introduces the `filterOutSelf` option to filter out the selected definition itself from the list, preventing interfaces from implementing themselves.