### PR TITLE
HCK-9575: add directives property mapping for FE

### DIFF
--- a/forward_engineering/mappers/customScalars.js
+++ b/forward_engineering/mappers/customScalars.js
@@ -1,12 +1,16 @@
 /**
  * @typedef { import("../types/types").FEStatement } FEStatement
+ * @typedef { import("../types/types").DirectivePropertyData } DirectivePropertyData
  */
+
+const { joinInlineStatements } = require('../helpers/feStatementJoinHelper');
+const { getDirectivesUsageStatement } = require('./directives');
 
 /**
  * @typedef {Object} CustomScalar
  * @property {string} description - The description of the custom scalar.
  * @property {boolean} isActivated - Indicates if the custom scalar is activated.
- * @property {Object} typeDirectives - The directives of the custom scalar. TODO: implement mapping
+ * @property {DirectivePropertyData[]} typeDirectives - The directives of the custom scalar.
  */
 
 /**
@@ -22,8 +26,11 @@
  * @returns {FEStatement}
  */
 function mapCustomScalar({ name, customScalar }) {
+	const customScalarNameStatement = `scalar ${name}`;
+	const directivesStatement = getDirectivesUsageStatement({ directives: customScalar.typeDirectives });
+
 	return {
-		statement: `scalar ${name}`, // TODO: add directives here
+		statement: joinInlineStatements({ statements: [customScalarNameStatement, directivesStatement] }),
 		description: customScalar.description,
 		isActivated: customScalar.isActivated,
 	};

--- a/forward_engineering/mappers/directives.js
+++ b/forward_engineering/mappers/directives.js
@@ -1,0 +1,35 @@
+/**
+ * @typedef { import("../types/types").DirectivePropertyData } DirectivePropertyData
+ */
+
+const { joinInlineStatements } = require('../helpers/feStatementJoinHelper');
+
+/**
+ * Gets the directives property as a string.
+ * @param {Object} param0
+ * @param {DirectivePropertyData[]} param0.directives
+ * @returns {String}
+ */
+function getDirectivesUsageStatement({ directives = [] }) {
+	const mappedDirectives = directives.map(directive => mapDirectiveUsage({ directive })).filter(Boolean);
+
+	return joinInlineStatements({ statements: mappedDirectives });
+}
+
+/**
+ * Maps a directive property to a string.
+ * New line characters are replaced with spaces to avoid breaking the statement.
+ * @param {Object} param0
+ * @param {DirectivePropertyData} param0.directive
+ * @returns {String}
+ */
+function mapDirectiveUsage({ directive }) {
+	if (directive.directiveFormat === 'Raw') {
+		return directive.rawDirective?.replace(/\n/g, ' ').trim() || '';
+	}
+	return '';
+}
+
+module.exports = {
+	getDirectivesUsageStatement,
+};

--- a/forward_engineering/mappers/enums.js
+++ b/forward_engineering/mappers/enums.js
@@ -1,21 +1,23 @@
 /**
  * @typedef { import("../types/types").FEStatement } FEStatement
+ * @typedef { import("../types/types").DirectivePropertyData } DirectivePropertyData
  */
 
 const { joinInlineStatements } = require('../helpers/feStatementJoinHelper');
+const { getDirectivesUsageStatement } = require('./directives');
 
 /**
  * @typedef {Object} EnumValue
  * @property {string} value - The name of the enum value.
  * @property {string} description - The description of the enum value.
- * @property {Object} valueDirectives - The directives of the enum value.
+ * @property {DirectivePropertyData[]} typeDirectives - The directives of the enum value.
  */
 
 /**
  * @typedef {Object} EnumDefinition
  * @property {string} description - The description of the enum.
  * @property {boolean} isActivated - Indicates if the enum is activated.
- * @property {Object} typeDirectives - The directives of the enum.
+ * @property {DirectivePropertyData[]} typeDirectives - The directives of the enum.
  * @property {EnumValue[]} enumValues - The values of the emu,.
  */
 
@@ -43,8 +45,11 @@ function getEnums({ enumsDefinitions }) {
  * @returns {FEStatement}
  */
 function mapEnum({ name, enumDefinition }) {
+	const nameStatement = `enum ${name}`;
+	const directivesStatement = getDirectivesUsageStatement({ directives: enumDefinition.typeDirectives });
+
 	return {
-		statement: joinInlineStatements({ statements: [`enum ${name}`] }), // TODO: add directives
+		statement: joinInlineStatements({ statements: [nameStatement, directivesStatement] }),
 		description: enumDefinition.description,
 		isActivated: enumDefinition.isActivated,
 		nestedStatements: mapEnumValues({ enumValues: enumDefinition.enumValues }),
@@ -59,10 +64,14 @@ function mapEnum({ name, enumDefinition }) {
  * @returns {FEStatement[]}
  */
 function mapEnumValues({ enumValues = [] }) {
-	return enumValues.map(({ value, description }) => ({
-		statement: joinInlineStatements({ statements: [value] }), // TODO: add directives
-		description: description,
-	}));
+	return enumValues.map(({ value, description, typeDirectives }) => {
+		const directivesStatement = getDirectivesUsageStatement({ directives: typeDirectives });
+
+		return {
+			statement: joinInlineStatements({ statements: [value, directivesStatement] }),
+			description: description,
+		};
+	});
 }
 
 module.exports = {

--- a/forward_engineering/types/types.d.ts
+++ b/forward_engineering/types/types.d.ts
@@ -5,3 +5,8 @@ export type FEStatement = {
 	nestedStatements?: FEStatement[];
 	useCurlyBracketsForNestedStatements?: boolean;
 }
+
+export type DirectivePropertyData = {
+	directiveFormat: 'Raw',
+	rawDirective: string;
+}

--- a/test/fe/directives.spec.js
+++ b/test/fe/directives.spec.js
@@ -1,0 +1,40 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { getDirectivesUsageStatement } = require('../../forward_engineering/mappers/directives');
+
+describe('getDirectivesUsageStatement', () => {
+	it('should return an empty string when no directives are provided', () => {
+		const result = getDirectivesUsageStatement({ directives: [] });
+		assert.strictEqual(result, '');
+	});
+
+	it('should return a single directive when one directive is provided', () => {
+		const directives = [{ directiveFormat: 'Raw', rawDirective: '@directive1' }];
+		const result = getDirectivesUsageStatement({ directives });
+		assert.strictEqual(result, '@directive1');
+	});
+
+	it('should return multiple directives joined by a space', () => {
+		const directives = [
+			{ directiveFormat: 'Raw', rawDirective: '@directive1' },
+			{ directiveFormat: 'Raw', rawDirective: '@directive2' },
+		];
+		const result = getDirectivesUsageStatement({ directives });
+		assert.strictEqual(result, '@directive1 @directive2');
+	});
+
+	it('should replace new lines in rawDirective with spaces', () => {
+		const directives = [{ directiveFormat: 'Raw', rawDirective: '@directive1\nline2' }];
+		const result = getDirectivesUsageStatement({ directives });
+		assert.strictEqual(result, '@directive1 line2');
+	});
+
+	it('should ignore directives that are not in Raw format', () => {
+		const directives = [
+			{ directiveFormat: 'NonRaw', rawDirective: '@directive1' },
+			{ directiveFormat: 'Raw', rawDirective: '@directive2' },
+		];
+		const result = getDirectivesUsageStatement({ directives });
+		assert.strictEqual(result, '@directive2');
+	});
+});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9575" title="HCK-9575" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9575</a>  Add directive property (from PP) FE
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR adds the `directives` property mapping for FE script generation.
It is now used for custom scalars, enums, and enum values.
It will be used for other type definitions when they are added. 