### PR TITLE
HCK-9648: move enum description higher than enum values

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -632,6 +632,7 @@ making sure that you maintain a proper JSON format.
 			],
 			"enum": [
 				"name",
+				"description",
 				{
 					"propertyName": "Enum values",
 					"propertyKeyword": "enumValues",
@@ -685,7 +686,6 @@ making sure that you maintain a proper JSON format.
 						}
 					]
 				},
-				"description",
 				{
 					"propertyName": "Required",
 					"propertyKeyword": "required",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9648" title="HCK-9648" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9648</a>  Enum Type: Put Description property before Enum values property
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

- Updated properties pane config

...

