### PR TITLE
HCK-9576, HCK-9579: add interfaces and input types FE

### DIFF
--- a/forward_engineering/mappers/fieldDefaultValue.js
+++ b/forward_engineering/mappers/fieldDefaultValue.js
@@ -1,0 +1,102 @@
+/**
+ * @import { FieldData } from "../types/types"
+ */
+
+/**
+ * Generates the default value statement for a field.
+ *
+ * @param {Object} param0
+ * @param {FieldData} param0.field - The field object.
+ * @returns {string} - The default value statement.
+ */
+function getFieldDefaultValueStatement({ field }) {
+	if (isValuePresent(field.default)) {
+		return `= ${formatFieldDefaultValue({ defaultValue: field.default, fieldType: field.type })}`;
+	}
+	if (isValuePresent(field.refDefaultValue)) {
+		return `= ${formatRefFieldDefaultValue({ defaultValue: field.refDefaultValue })}`;
+	}
+
+	return '';
+}
+
+/**
+ * Formats the default value for a field.
+ *
+ * @param {Object} param0
+ * @param {unknown} param0.defaultValue - The default value.
+ * @param {string} param0.fieldType - The type of the field.
+ * @returns {string} - The formatted default value.
+ */
+function formatFieldDefaultValue({ defaultValue, fieldType }) {
+	if (fieldType === 'List' && isComplexDefaultValue({ defaultValue })) {
+		return prepareComplexDefaultValue({ defaultValue });
+	}
+
+	try {
+		return JSON.stringify(defaultValue);
+	} catch {
+		return String(defaultValue);
+	}
+}
+
+/**
+ * Formats the default value for a reference field.
+ *
+ * @param {Object} param0
+ * @param {any} param0.defaultValue - The default value.
+ * @returns {string} - The formatted default value.
+ */
+function formatRefFieldDefaultValue({ defaultValue }) {
+	if (isComplexDefaultValue({ defaultValue })) {
+		return prepareComplexDefaultValue({ defaultValue });
+	}
+	try {
+		return JSON.stringify(JSON.parse(defaultValue));
+	} catch {
+		return `"${String(defaultValue)}"`;
+	}
+}
+
+/**
+ * Checks if the default value is complex (object or array).
+ *
+ * @param {Object} param0
+ * @param {unknown} param0.defaultValue - The default value.
+ * @returns {boolean} - True if the default value is complex, false otherwise.
+ */
+function isComplexDefaultValue({ defaultValue }) {
+	if (typeof defaultValue !== 'string') {
+		return false;
+	}
+	const trimmedDefaultValue = defaultValue.trim();
+	return (
+		(trimmedDefaultValue.startsWith('{') && trimmedDefaultValue.endsWith('}')) ||
+		(trimmedDefaultValue.startsWith('[') && trimmedDefaultValue.endsWith(']'))
+	);
+}
+
+/**
+ * Checks if a value is present (not undefined or empty).
+ *
+ * @param {unknown} value - The value to check.
+ * @returns {boolean} - True if the value is present, false otherwise.
+ */
+function isValuePresent(value) {
+	return value !== undefined && value !== '';
+}
+
+/**
+ * Prepares a complex default value by removing newlines.
+ *
+ * @param {Object} param0
+ * @param {string} param0.defaultValue - The default value.
+ * @returns {string} - The prepared default value.
+ */
+function prepareComplexDefaultValue({ defaultValue }) {
+	return defaultValue.trim().replace(/\n/g, ' ');
+}
+
+module.exports = {
+	getFieldDefaultValueStatement,
+};

--- a/forward_engineering/mappers/fieldDefaultValue.js
+++ b/forward_engineering/mappers/fieldDefaultValue.js
@@ -10,14 +10,15 @@
  * @returns {string} - The default value statement.
  */
 function getFieldDefaultValueStatement({ field }) {
-	if (isValuePresent(field.default)) {
-		return `= ${formatFieldDefaultValue({ defaultValue: field.default, fieldType: field.type })}`;
-	}
-	if (isValuePresent(field.refDefaultValue)) {
-		return `= ${formatRefFieldDefaultValue({ defaultValue: field.refDefaultValue })}`;
+	if (!isValuePresent(field.default)) {
+		return '';
 	}
 
-	return '';
+	if (field.$ref) {
+		return `= ${formatRefFieldDefaultValue({ defaultValue: field.default })}`;
+	}
+
+	return `= ${formatFieldDefaultValue({ defaultValue: field.default, fieldType: field.type })}`;
 }
 
 /**

--- a/forward_engineering/mappers/fields.js
+++ b/forward_engineering/mappers/fields.js
@@ -6,23 +6,33 @@ const { joinInlineStatements } = require('../helpers/feStatementJoinHelper');
 const { getDefinitionNameFromReferencePath } = require('../helpers/referencesHelper');
 const { getArguments } = require('./arguments');
 const { getDirectivesUsageStatement } = require('./directiveUsageStatements');
+const { getFieldDefaultValueStatement } = require('./fieldDefaultValue');
 
 /**
  * @typedef {Object.<string, FieldData>} FieldsData
  */
 
 /**
- * Gets the object types from the model definitions.
+ * Gets the fields from the model definitions.
  *
  * @param {Object} param0
- * @param {FieldsData} param0.fields - The object types to get.
+ * @param {FieldsData} param0.fields - The fields to get.
  * @param {string[]} param0.requiredFields - The required fields list.
  * @param {IdToNameMap} param0.definitionsIdToNameMap - The definitions id to name map.
- * @returns {FEStatement[]} - The object types.
+ * @param {boolean} param0.addArguments - Indicates if arguments should be added.
+ * @param {boolean} param0.addDefaultValue - Indicates if default value should be added.
+ * @returns {FEStatement[]} - The fields.
  */
-function getFields({ fields, requiredFields = [], definitionsIdToNameMap }) {
+function getFields({ fields, requiredFields = [], definitionsIdToNameMap, addArguments, addDefaultValue }) {
 	return Object.entries(fields).map(([name, fieldData]) =>
-		mapField({ name, fieldData, required: requiredFields.includes(name), definitionsIdToNameMap }),
+		mapField({
+			name,
+			fieldData,
+			required: requiredFields.includes(name),
+			definitionsIdToNameMap,
+			addArguments,
+			addDefaultValue,
+		}),
 	);
 }
 
@@ -34,16 +44,21 @@ function getFields({ fields, requiredFields = [], definitionsIdToNameMap }) {
  * @param {FieldData} param0.fieldData - The field data object.
  * @param {boolean} param0.required - Indicates if the field is required.
  * @param {IdToNameMap} param0.definitionsIdToNameMap - The definitions id to name map.
+ * @param {boolean} param0.addArguments - Indicates if arguments should be added.
+ * @param {boolean} param0.addDefaultValue - Indicates if default value should be added.
  * @returns {FEStatement}
  */
-function mapField({ name, fieldData, required, definitionsIdToNameMap }) {
-	const fieldArguments = getArguments({ graphqlArguments: fieldData.arguments, idToNameMap: definitionsIdToNameMap });
+function mapField({ name, fieldData, required, definitionsIdToNameMap, addArguments, addDefaultValue }) {
+	const fieldArguments = addArguments
+		? getArguments({ graphqlArguments: fieldData.arguments, idToNameMap: definitionsIdToNameMap })
+		: '';
 	const fieldNameStatement = joinInlineStatements({ statements: [name, fieldArguments] });
 	const fieldTypeStatement = `${fieldNameStatement}: ${getFieldType({ field: fieldData, required })}`;
-	const directivesStatement = getDirectivesUsageStatement({ directives: fieldData.typeDirectives });
+	const fieldDefaultValue = addDefaultValue ? getFieldDefaultValueStatement({ field: fieldData }) : '';
+	const directivesStatement = getDirectivesUsageStatement({ directives: fieldData.fieldDirectives });
 
 	return {
-		statement: joinInlineStatements({ statements: [fieldTypeStatement, directivesStatement] }),
+		statement: joinInlineStatements({ statements: [fieldTypeStatement, fieldDefaultValue, directivesStatement] }),
 		description: fieldData.refDescription || fieldData.description,
 		isActivated: fieldData.isActivated,
 	};
@@ -104,7 +119,9 @@ function addRequiredField({ field, required }) {
 }
 
 module.exports = {
-	getFields,
+	getObjectTypeFields: params => getFields({ ...params, addArguments: true, addDefaultValue: false }),
+	getInterfaceTypeFields: params => getFields({ ...params, addArguments: true, addDefaultValue: false }),
+	getInputTypeFields: params => getFields({ ...params, addArguments: false, addDefaultValue: true }),
 	// exported only for tests:
 	mapField,
 	getFieldType,

--- a/forward_engineering/mappers/objectLikeType.js
+++ b/forward_engineering/mappers/objectLikeType.js
@@ -1,5 +1,5 @@
 /**
- * @import { FEStatement, DirectivePropertyData, ObjectTypeDefinition, ObjectTypeDefinitions, IdToNameMap, ImplementsInterface } from "../types/types"
+ * @import { FEStatement, DirectivePropertyData, ObjectLikeTypeDefinition, ObjectLikeTypeDefinitions, IdToNameMap, ImplementsInterface } from "../types/types"
  */
 
 const { joinInlineStatements } = require('../helpers/feStatementJoinHelper');
@@ -10,7 +10,7 @@ const { getImplementsInterfacesStatement } = require('./implementsInterfaces');
  * Gets the object-like types from the model definitions.
  *
  * @param {Object} param0
- * @param {ObjectTypeDefinitions} param0.objectTypes - The object-like types to get.
+ * @param {ObjectLikeTypeDefinitions} param0.objectTypes - The object-like types to get.
  * @param {IdToNameMap} param0.definitionsIdToNameMap - The definitions id to name map.
  * @param {string} param0.typeKeyword - The type keyword ("type", "interface", "input").
  * @param {Function} param0.getFieldsFunction - The function to get fields for the type.
@@ -27,7 +27,7 @@ function getObjectLikeTypes({ objectTypes, definitionsIdToNameMap, typeKeyword, 
  *
  * @param {Object} param0
  * @param {string} param0.name - The name of the object.
- * @param {ObjectTypeDefinition} param0.objectType - The object type definition object.
+ * @param {ObjectLikeTypeDefinition} param0.objectType - The object-like type definition object.
  * @param {IdToNameMap} param0.definitionsIdToNameMap - The definitions id to name map.
  * @param {string} param0.typeKeyword - The type keyword ("type", "interface", "input").
  * @param {Function} param0.getFieldsFunction - The function to get fields for the type.

--- a/forward_engineering/mappers/objectLikeType.js
+++ b/forward_engineering/mappers/objectLikeType.js
@@ -4,34 +4,37 @@
 
 const { joinInlineStatements } = require('../helpers/feStatementJoinHelper');
 const { getDirectivesUsageStatement } = require('./directiveUsageStatements');
-const { getFields } = require('./fields');
 const { getImplementsInterfacesStatement } = require('./implementsInterfaces');
 
 /**
- * Gets the object types from the model definitions.
+ * Gets the object-like types from the model definitions.
  *
  * @param {Object} param0
- * @param {ObjectTypeDefinitions} param0.objectTypes - The object types to get.
+ * @param {ObjectTypeDefinitions} param0.objectTypes - The object-like types to get.
  * @param {IdToNameMap} param0.definitionsIdToNameMap - The definitions id to name map.
- * @returns {FEStatement[]} - The object types.
+ * @param {string} param0.typeKeyword - The type keyword ("type", "interface", "input").
+ * @param {Function} param0.getFieldsFunction - The function to get fields for the type.
+ * @returns {FEStatement[]} - The object-like types.
  */
-function getObjectTypes({ objectTypes, definitionsIdToNameMap }) {
+function getObjectLikeTypes({ objectTypes, definitionsIdToNameMap, typeKeyword, getFieldsFunction }) {
 	return Object.entries(objectTypes).map(([name, objectType]) =>
-		mapObjectType({ name, objectType, definitionsIdToNameMap }),
+		mapObjectLikeType({ name, objectType, definitionsIdToNameMap, typeKeyword, getFieldsFunction }),
 	);
 }
 
 /**
- * Maps an object type to an FEStatement.
+ * Maps an object-like type to an FEStatement.
  *
  * @param {Object} param0
  * @param {string} param0.name - The name of the object.
  * @param {ObjectTypeDefinition} param0.objectType - The object type definition object.
  * @param {IdToNameMap} param0.definitionsIdToNameMap - The definitions id to name map.
+ * @param {string} param0.typeKeyword - The type keyword ("type", "interface", "input").
+ * @param {Function} param0.getFieldsFunction - The function to get fields for the type.
  * @returns {FEStatement}
  */
-function mapObjectType({ name, objectType, definitionsIdToNameMap }) {
-	const nameStatement = `type ${name}`;
+function mapObjectLikeType({ name, objectType, definitionsIdToNameMap, typeKeyword, getFieldsFunction }) {
+	const nameStatement = `${typeKeyword} ${name}`;
 	const implementsInterfacesStatement = getImplementsInterfacesStatement({
 		interfaces: objectType.implementsInterfaces,
 		definitionsIdToNameMap,
@@ -44,7 +47,7 @@ function mapObjectType({ name, objectType, definitionsIdToNameMap }) {
 		}),
 		description: objectType.description,
 		isActivated: objectType.isActivated,
-		nestedStatements: getFields({
+		nestedStatements: getFieldsFunction({
 			fields: objectType.properties,
 			requiredFields: objectType.required,
 			definitionsIdToNameMap,
@@ -53,5 +56,5 @@ function mapObjectType({ name, objectType, definitionsIdToNameMap }) {
 }
 
 module.exports = {
-	getObjectTypes,
+	getObjectLikeTypes,
 };

--- a/forward_engineering/mappers/objectLikeType.js
+++ b/forward_engineering/mappers/objectLikeType.js
@@ -35,10 +35,15 @@ function getObjectLikeTypes({ objectTypes, definitionsIdToNameMap, typeKeyword, 
  */
 function mapObjectLikeType({ name, objectType, definitionsIdToNameMap, typeKeyword, getFieldsFunction }) {
 	const nameStatement = `${typeKeyword} ${name}`;
-	const implementsInterfacesStatement = getImplementsInterfacesStatement({
-		interfaces: objectType.implementsInterfaces,
-		definitionsIdToNameMap,
-	});
+
+	let implementsInterfacesStatement = '';
+	if (typeKeyword === 'type' || typeKeyword === 'interface') {
+		implementsInterfacesStatement = getImplementsInterfacesStatement({
+			interfaces: objectType.implementsInterfaces,
+			definitionsIdToNameMap,
+		});
+	}
+
 	const directivesStatement = getDirectivesUsageStatement({ directives: objectType.typeDirectives });
 
 	return {

--- a/forward_engineering/mappers/typeDefinitions.js
+++ b/forward_engineering/mappers/typeDefinitions.js
@@ -6,8 +6,9 @@ const { formatFEStatement } = require('../helpers/feStatementFormatHelper');
 const { getCustomScalars } = require('./customScalars');
 const { getEnums } = require('./enums');
 const { getDirectives } = require('./directives');
-const { getObjectTypes } = require('./objectType');
+const { getObjectLikeTypes } = require('./objectLikeType');
 const { getUnions } = require('./unions');
+const { getObjectTypeFields, getInterfaceTypeFields, getInputTypeFields } = require('./fields');
 
 /**
  * Gets the type definition statements from model definitions.
@@ -26,13 +27,35 @@ function getTypeDefinitionStatements({ modelDefinitions, definitionsIdToNameMap 
 		customScalars: getModelDefinitionsBySubtype({ modelDefinitions, subtype: 'scalar' }),
 	});
 	const enums = getEnums({ enumsDefinitions: getModelDefinitionsBySubtype({ modelDefinitions, subtype: 'enum' }) });
-	const objectTypes = getObjectTypes({
+	const objectTypes = getObjectLikeTypes({
 		objectTypes: getModelDefinitionsBySubtype({ modelDefinitions, subtype: 'object' }),
 		definitionsIdToNameMap,
+		typeKeyword: 'type',
+		getFieldsFunction: getObjectTypeFields,
+	});
+	const interfaceTypes = getObjectLikeTypes({
+		objectTypes: getModelDefinitionsBySubtype({ modelDefinitions, subtype: 'interface' }),
+		definitionsIdToNameMap,
+		typeKeyword: 'interface',
+		getFieldsFunction: getInterfaceTypeFields,
+	});
+	const inputTypes = getObjectLikeTypes({
+		objectTypes: getModelDefinitionsBySubtype({ modelDefinitions, subtype: 'input' }),
+		definitionsIdToNameMap,
+		typeKeyword: 'input',
+		getFieldsFunction: getInputTypeFields,
 	});
 	const unions = getUnions({ unions: getModelDefinitionsBySubtype({ modelDefinitions, subtype: 'union' }) });
 
-	const typeDefinitions = [...directives, ...customScalars, ...enums, ...objectTypes, ...unions];
+	const typeDefinitions = [
+		...directives,
+		...customScalars,
+		...enums,
+		...objectTypes,
+		...interfaceTypes,
+		...inputTypes,
+		...unions,
+	];
 	const formattedTypeDefinitions = typeDefinitions
 		.map(typeDefinition => formatFEStatement({ feStatement: typeDefinition }))
 		.join('\n\n');

--- a/forward_engineering/types/types.d.ts
+++ b/forward_engineering/types/types.d.ts
@@ -41,7 +41,7 @@ type ReferenceFieldData = {
 	refDescription?: string; // Description of the reference
 	fieldDirectives?: DirectivePropertyData[]; // Directives for the field
 	arguments?: Argument[]; // Arguments of the field
-	refDefaultValue?: unknown; // Default value of the reference
+	default?: unknown; // Default value of the reference
 }
 
 export type ArrayItem = FieldData & {

--- a/forward_engineering/types/types.d.ts
+++ b/forward_engineering/types/types.d.ts
@@ -29,17 +29,19 @@ type RegularFieldData = {
 	type: string; // Type of the field
 	isActivated?: boolean; // If the field is activated
 	description?: string; // Description of the field
-	typeDirectives?: DirectivePropertyData[]; // Directives for the type
+	fieldDirectives?: DirectivePropertyData[]; // Directives for the field
 	items?: ArrayItem | ArrayItem[]; // Items of the List type
 	arguments?: Argument[]; // Arguments of the field
+	default?: unknown; // Default value of the field
 }
 
 type ReferenceFieldData = {
 	$ref: string; // Reference path to the type definition
 	isActivated?: boolean; // If the field is activated
 	refDescription?: string; // Description of the reference
-	typeDirectives?: DirectivePropertyData[]; // Directives for the type
+	fieldDirectives?: DirectivePropertyData[]; // Directives for the field
 	arguments?: Argument[]; // Arguments of the field
+	refDefaultValue?: unknown; // Default value of the reference
 }
 
 export type ArrayItem = FieldData & {

--- a/forward_engineering/types/types.d.ts
+++ b/forward_engineering/types/types.d.ts
@@ -12,9 +12,9 @@ export type FEStatement = {
 export type IdToNameMap = Record<string, string>;
 
 // Object type definition
-export type ObjectTypeDefinitions = Record<string, ObjectTypeDefinition>;
+export type ObjectLikeTypeDefinitions = Record<string, ObjectLikeTypeDefinition>;
 
-export type ObjectTypeDefinition = {
+export type ObjectLikeTypeDefinition = {
 	description?: string; // Description of the object type
 	isActivated?: boolean; // If the object type is activated
 	implementsInterfaces?: ImplementsInterface[]; // Interfaces that the object type implements

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -623,7 +623,7 @@ making sure that you maintain a proper JSON format.
 				},
 				{
 					"propertyName": "Default",
-					"propertyKeyword": "refDefaultValue",
+					"propertyKeyword": "default",
 					"propertyType": "text",
 					"propertyTooltip": "Enter default value",
 					"enableForReference": true,

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -140,6 +140,7 @@ making sure that you maintain a proper JSON format.
 					"propertyType": "checkbox",
 					"propertyTooltip": "Check if this field is required"
 				},
+				"default",
 				{
 					"propertyName": "Directives",
 					"propertyKeyword": "fieldDirectives",
@@ -179,7 +180,6 @@ making sure that you maintain a proper JSON format.
 				"foreignCollection",
 				"foreignField",
 				"relationshipType",
-				"default",
 				"minLength",
 				"maxLength",
 				"pattern",
@@ -207,6 +207,7 @@ making sure that you maintain a proper JSON format.
 					"propertyType": "checkbox",
 					"propertyTooltip": "Check if this field is required"
 				},
+				"default",
 				{
 					"propertyName": "Directives",
 					"propertyKeyword": "fieldDirectives",
@@ -243,7 +244,6 @@ making sure that you maintain a proper JSON format.
 					]
 				},
 				"primaryKey",
-				"default",
 				"unit",
 				"minimum",
 				"exclusiveMinimum",
@@ -276,6 +276,7 @@ making sure that you maintain a proper JSON format.
 					"propertyType": "checkbox",
 					"propertyTooltip": "Check if this field is required"
 				},
+				"default",
 				{
 					"propertyName": "Directives",
 					"propertyKeyword": "fieldDirectives",
@@ -311,7 +312,6 @@ making sure that you maintain a proper JSON format.
 						}
 					]
 				},
-				"default",
 				"unit",
 				"minimum",
 				"exclusiveMinimum",
@@ -343,6 +343,7 @@ making sure that you maintain a proper JSON format.
 					"propertyType": "checkbox",
 					"propertyTooltip": "Check if this field is required"
 				},
+				"default",
 				{
 					"propertyName": "Directives",
 					"propertyKeyword": "fieldDirectives",
@@ -382,7 +383,6 @@ making sure that you maintain a proper JSON format.
 				"foreignCollection",
 				"foreignField",
 				"relationshipType",
-				"default",
 				"minLength",
 				"maxLength",
 				"pattern",
@@ -410,6 +410,7 @@ making sure that you maintain a proper JSON format.
 					"propertyType": "checkbox",
 					"propertyTooltip": "Check if this field is required"
 				},
+				"default",
 				{
 					"propertyName": "Directives",
 					"propertyKeyword": "fieldDirectives",
@@ -445,7 +446,6 @@ making sure that you maintain a proper JSON format.
 						}
 					]
 				},
-				"default",
 				"sample",
 				"comments"
 			],
@@ -467,6 +467,49 @@ making sure that you maintain a proper JSON format.
 					"propertyName": "Required",
 					"propertyType": "checkbox",
 					"propertyTooltip": "Check if this field is required"
+				},
+				{
+					"propertyName": "Default",
+					"propertyKeyword": "default",
+					"propertyType": "details",
+					"template": "textarea",
+					"markdown": false,
+					"propertyTooltip": "Enter default value, for example: [\"value1\", \"value2\"]"
+				},
+				{
+					"propertyName": "Directives",
+					"propertyKeyword": "fieldDirectives",
+					"propertyTooltip": "Field directives",
+					"propertyType": "group",
+					"structure": [
+						{
+							"propertyName": "Directive format",
+							"propertyKeyword": "directiveFormat",
+							"propertyTooltip": "Select directive format",
+							"propertyType": "select",
+							"options": ["Raw"],
+							"defaultValue": "Raw",
+							"helpInfo": {
+								"type": "modal",
+								"title": "PROPERTIES_PANE___DIRECTIVES_INFO_MODAL_TITLE",
+								"content": "PROPERTIES_PANE___DIRECTIVES_INFO_MODAL_BODY",
+								"featureNameForHelp": "GraphQL directives",
+								"buttons": ["contactSupport", "ok"]
+							}
+						},
+						{
+							"propertyName": "Raw directive",
+							"propertyKeyword": "rawDirective",
+							"propertyTooltip": "Enter raw directive",
+							"propertyType": "details",
+							"template": "textarea",
+							"markdown": false,
+							"dependency": {
+								"key": "directiveFormat",
+								"value": "Raw"
+							}
+						}
+					]
 				},
 				"minItems",
 				"maxItems",
@@ -579,6 +622,17 @@ making sure that you maintain a proper JSON format.
 					}
 				},
 				{
+					"propertyName": "Default",
+					"propertyKeyword": "refDefaultValue",
+					"propertyType": "text",
+					"propertyTooltip": "Enter default value",
+					"enableForReference": true,
+					"dependency": {
+						"key": "ref",
+						"exist": true
+					}
+				},
+				{
 					"propertyName": "Directives",
 					"propertyKeyword": "fieldDirectives",
 					"propertyTooltip": "Field directives",
@@ -623,6 +677,28 @@ making sure that you maintain a proper JSON format.
 			"enum": [
 				"name",
 				"description",
+				{
+					"propertyName": "Required",
+					"propertyKeyword": "required",
+					"propertyType": "checkbox",
+					"propertyTooltip": "Check if this field is required",
+					"enableForReference": true,
+					"dependency": {
+						"key": "ref",
+						"exist": true
+					}
+				},
+				{
+					"propertyName": "Default",
+					"propertyKeyword": "refDefaultValue",
+					"propertyType": "text",
+					"propertyTooltip": "Enter default value",
+					"enableForReference": true,
+					"dependency": {
+						"key": "ref",
+						"exist": true
+					}
+				},
 				{
 					"propertyName": "Enum values",
 					"propertyKeyword": "enumValues",
@@ -675,17 +751,6 @@ making sure that you maintain a proper JSON format.
 							]
 						}
 					]
-				},
-				{
-					"propertyName": "Required",
-					"propertyKeyword": "required",
-					"propertyType": "checkbox",
-					"propertyTooltip": "Check if this field is required",
-					"enableForReference": true,
-					"dependency": {
-						"key": "ref",
-						"exist": true
-					}
 				},
 				{
 					"propertyName": "Directives",
@@ -1066,6 +1131,19 @@ making sure that you maintain a proper JSON format.
 					"propertyType": "checkbox",
 					"propertyTooltip": "Check if this field is required",
 					"enableForReference": true,
+					"dependency": {
+						"key": "ref",
+						"exist": true
+					}
+				},
+				{
+					"propertyName": "Default",
+					"propertyKeyword": "refDefaultValue",
+					"propertyType": "details",
+					"template": "textarea",
+					"markdown": false,
+					"enableForReference": true,
+					"propertyTooltip": "Enter default value, for example: {key1: \"value1\", key2: \"value2\"}",
 					"dependency": {
 						"key": "ref",
 						"exist": true

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -690,7 +690,7 @@ making sure that you maintain a proper JSON format.
 				},
 				{
 					"propertyName": "Default",
-					"propertyKeyword": "refDefaultValue",
+					"propertyKeyword": "default",
 					"propertyType": "text",
 					"propertyTooltip": "Enter default value",
 					"enableForReference": true,
@@ -1138,7 +1138,7 @@ making sure that you maintain a proper JSON format.
 				},
 				{
 					"propertyName": "Default",
-					"propertyKeyword": "refDefaultValue",
+					"propertyKeyword": "default",
 					"propertyType": "details",
 					"template": "textarea",
 					"markdown": false,

--- a/test/forward_engineering/mappers/fieldDefaultValue.spec.js
+++ b/test/forward_engineering/mappers/fieldDefaultValue.spec.js
@@ -1,0 +1,53 @@
+const { describe, it } = require('node:test');
+const assert = require('assert');
+const { getFieldDefaultValueStatement } = require('../../../forward_engineering/mappers/fieldDefaultValue');
+
+describe('getFieldDefaultValueStatement', () => {
+	it('should return the default value statement for a regular field', () => {
+		const field = { type: 'String', default: 'defaultString' };
+		const result = getFieldDefaultValueStatement({ field });
+		assert.strictEqual(result, '= "defaultString"');
+	});
+
+	it('should return the default value statement for a reference field', () => {
+		const field = { $ref: '1', refDefaultValue: 'defaultRefValue' };
+		const result = getFieldDefaultValueStatement({ field });
+		assert.strictEqual(result, '= "defaultRefValue"');
+	});
+
+	it('should return the default value statement for a list field with a complex default value', () => {
+		const field = { type: 'List', default: '[1, 2, 3]' };
+		const result = getFieldDefaultValueStatement({ field });
+		assert.strictEqual(result, '= [1, 2, 3]');
+	});
+
+	it('should return an empty string if no default value is present', () => {
+		const field = { type: 'String' };
+		const result = getFieldDefaultValueStatement({ field });
+		assert.strictEqual(result, '');
+	});
+
+	it('should return the default value statement for a number type field', () => {
+		const field = { type: 'Int', default: 42 };
+		const result = getFieldDefaultValueStatement({ field });
+		assert.strictEqual(result, '= 42');
+	});
+
+	it('should return the default value statement for a reference field with a number default value', () => {
+		const field = { $ref: '1', refDefaultValue: '42' };
+		const result = getFieldDefaultValueStatement({ field });
+		assert.strictEqual(result, '= 42');
+	});
+
+	it('should format a complex reference default value', () => {
+		const field = { $ref: '1', refDefaultValue: '{ name: "sample name" }' };
+		const result = getFieldDefaultValueStatement({ field });
+		assert.strictEqual(result, '= { name: "sample name" }');
+	});
+
+	it('should prepare a complex default value by replacing newlines with spaces', () => {
+		const field = { type: 'List', default: '[\n1,\n2,\n3\n]' };
+		const result = getFieldDefaultValueStatement({ field });
+		assert.strictEqual(result, '= [ 1, 2, 3 ]');
+	});
+});

--- a/test/forward_engineering/mappers/fieldDefaultValue.spec.js
+++ b/test/forward_engineering/mappers/fieldDefaultValue.spec.js
@@ -10,7 +10,7 @@ describe('getFieldDefaultValueStatement', () => {
 	});
 
 	it('should return the default value statement for a reference field', () => {
-		const field = { $ref: '1', refDefaultValue: 'defaultRefValue' };
+		const field = { $ref: '1', default: 'defaultRefValue' };
 		const result = getFieldDefaultValueStatement({ field });
 		assert.strictEqual(result, '= "defaultRefValue"');
 	});
@@ -34,13 +34,13 @@ describe('getFieldDefaultValueStatement', () => {
 	});
 
 	it('should return the default value statement for a reference field with a number default value', () => {
-		const field = { $ref: '1', refDefaultValue: '42' };
+		const field = { $ref: '1', default: '42' };
 		const result = getFieldDefaultValueStatement({ field });
 		assert.strictEqual(result, '= 42');
 	});
 
 	it('should format a complex reference default value', () => {
-		const field = { $ref: '1', refDefaultValue: '{ name: "sample name" }' };
+		const field = { $ref: '1', default: '{ name: "sample name" }' };
 		const result = getFieldDefaultValueStatement({ field });
 		assert.strictEqual(result, '= { name: "sample name" }');
 	});

--- a/test/forward_engineering/mappers/fields.spec.js
+++ b/test/forward_engineering/mappers/fields.spec.js
@@ -5,6 +5,7 @@ const joinInlineStatementsMock = mock.fn();
 const getDefinitionNameFromReferencePathMock = mock.fn(() => '');
 const getArgumentsMock = mock.fn(() => '');
 const getDirectivesUsageStatementMock = mock.fn(() => '');
+const getFieldDefaultValueStatementMock = mock.fn(() => '');
 
 mock.module('../../../forward_engineering/helpers/feStatementJoinHelper', {
 	namedExports: {
@@ -26,9 +27,20 @@ mock.module('../../../forward_engineering/mappers/directiveUsageStatements', {
 		getDirectivesUsageStatement: getDirectivesUsageStatementMock,
 	},
 });
+mock.module('../../../forward_engineering/mappers/fieldDefaultValue', {
+	namedExports: {
+		getFieldDefaultValueStatement: getFieldDefaultValueStatementMock,
+	},
+});
 
 // This require should be after the mocks to ensure that the mocks are applied before the module is required
-const { getFields, mapField, getFieldType } = require('../../../forward_engineering/mappers/fields');
+const {
+	getObjectTypeFields,
+	getInterfaceTypeFields,
+	getInputTypeFields,
+	mapField,
+	getFieldType,
+} = require('../../../forward_engineering/mappers/fields');
 
 describe('mapField', () => {
 	afterEach(() => {
@@ -36,6 +48,7 @@ describe('mapField', () => {
 		getDefinitionNameFromReferencePathMock.mock.resetCalls();
 		joinInlineStatementsMock.mock.resetCalls();
 		getArgumentsMock.mock.resetCalls();
+		getFieldDefaultValueStatementMock.mock.resetCalls();
 	});
 
 	it('should map a field to an FEStatement', () => {
@@ -49,7 +62,14 @@ describe('mapField', () => {
 		joinInlineStatementsMock.mock.mockImplementationOnce(() => `${name}: String`, 1);
 		getDirectivesUsageStatementMock.mock.mockImplementationOnce(() => '');
 
-		const result = mapField({ name, fieldData, required, definitionsIdToNameMap });
+		const result = mapField({
+			name,
+			fieldData,
+			required,
+			definitionsIdToNameMap,
+			addArguments: true,
+			addDefaultValue: false,
+		});
 
 		deepStrictEqual(result, {
 			statement: `${name}: String`,
@@ -57,9 +77,48 @@ describe('mapField', () => {
 			isActivated: true,
 		});
 	});
+
+	it('should map a field to an FEStatement with default value', () => {
+		const name = 'field1';
+		const fieldData = {
+			type: 'String',
+			description: 'A string field',
+			isActivated: true,
+			default: 'defaultString',
+		};
+		const required = false;
+		const definitionsIdToNameMap = {};
+
+		joinInlineStatementsMock.mock.mockImplementationOnce(() => name, 0);
+		joinInlineStatementsMock.mock.mockImplementationOnce(() => `${name}: String`, 1);
+		getDirectivesUsageStatementMock.mock.mockImplementationOnce(() => '');
+		getFieldDefaultValueStatementMock.mock.mockImplementationOnce(() => '= "defaultString"');
+
+		const result = mapField({
+			name,
+			fieldData,
+			required,
+			definitionsIdToNameMap,
+			addArguments: false,
+			addDefaultValue: true,
+		});
+
+		deepStrictEqual(result, {
+			statement: `${name}: String`,
+			description: 'A string field',
+			isActivated: true,
+		});
+
+		// Verify that joinInlineStatementsMock was called with the correct default value
+		deepStrictEqual(joinInlineStatementsMock.mock.calls[1].arguments[0].statements, [
+			`${name}: String`,
+			'= "defaultString"',
+			'',
+		]);
+	});
 });
 
-describe('getFields', () => {
+describe('getObjectTypeFields', () => {
 	afterEach(() => {
 		getDirectivesUsageStatementMock.mock.resetCalls();
 		getDefinitionNameFromReferencePathMock.mock.resetCalls();
@@ -67,7 +126,7 @@ describe('getFields', () => {
 		getArgumentsMock.mock.resetCalls();
 	});
 
-	it('should return an array of FEStatements', () => {
+	it('should return an array of FEStatements for object type fields', () => {
 		const fields = {
 			field1: { type: 'String' },
 			field2: { type: 'Int' },
@@ -75,7 +134,53 @@ describe('getFields', () => {
 		const requiredFields = ['field1'];
 		const definitionsIdToNameMap = {};
 
-		const result = getFields({ fields, requiredFields, definitionsIdToNameMap });
+		const result = getObjectTypeFields({ fields, requiredFields, definitionsIdToNameMap });
+
+		strictEqual(Array.isArray(result), true);
+		strictEqual(result.length, 2);
+	});
+});
+
+describe('getInterfaceTypeFields', () => {
+	afterEach(() => {
+		getDirectivesUsageStatementMock.mock.resetCalls();
+		getDefinitionNameFromReferencePathMock.mock.resetCalls();
+		joinInlineStatementsMock.mock.resetCalls();
+		getArgumentsMock.mock.resetCalls();
+	});
+
+	it('should return an array of FEStatements for interface type fields', () => {
+		const fields = {
+			field1: { type: 'String' },
+			field2: { type: 'Int' },
+		};
+		const requiredFields = ['field1'];
+		const definitionsIdToNameMap = {};
+
+		const result = getInterfaceTypeFields({ fields, requiredFields, definitionsIdToNameMap });
+
+		strictEqual(Array.isArray(result), true);
+		strictEqual(result.length, 2);
+	});
+});
+
+describe('getInputTypeFields', () => {
+	afterEach(() => {
+		getDirectivesUsageStatementMock.mock.resetCalls();
+		getDefinitionNameFromReferencePathMock.mock.resetCalls();
+		joinInlineStatementsMock.mock.resetCalls();
+		getArgumentsMock.mock.resetCalls();
+	});
+
+	it('should return an array of FEStatements for input type fields', () => {
+		const fields = {
+			field1: { type: 'String', default: 'defaultString' },
+			field2: { type: 'Int', default: 0 },
+		};
+		const requiredFields = ['field1'];
+		const definitionsIdToNameMap = {};
+
+		const result = getInputTypeFields({ fields, requiredFields, definitionsIdToNameMap });
 
 		strictEqual(Array.isArray(result), true);
 		strictEqual(result.length, 2);

--- a/test/forward_engineering/mappers/objectLikeType.spec.js
+++ b/test/forward_engineering/mappers/objectLikeType.spec.js
@@ -1,0 +1,162 @@
+const { describe, it, mock, afterEach } = require('node:test');
+const { strictEqual, deepStrictEqual } = require('assert');
+
+const joinInlineStatementsMock = mock.fn();
+const getDirectivesUsageStatementMock = mock.fn(() => '');
+const getImplementsInterfacesStatementMock = mock.fn(() => '');
+
+mock.module('../../../forward_engineering/helpers/feStatementJoinHelper', {
+	namedExports: {
+		joinInlineStatements: joinInlineStatementsMock,
+	},
+});
+mock.module('../../../forward_engineering/mappers/directiveUsageStatements', {
+	namedExports: {
+		getDirectivesUsageStatement: getDirectivesUsageStatementMock,
+	},
+});
+mock.module('../../../forward_engineering/mappers/implementsInterfaces', {
+	namedExports: {
+		getImplementsInterfacesStatement: getImplementsInterfacesStatementMock,
+	},
+});
+
+// This require should be after the mocks to ensure that the mocks are applied before the module is required
+const { getObjectLikeTypes } = require('../../../forward_engineering/mappers/objectLikeType');
+
+describe('getObjectLikeTypes', () => {
+	const definitionsIdToNameMap = {};
+
+	afterEach(() => {
+		joinInlineStatementsMock.mock.resetCalls();
+		getDirectivesUsageStatementMock.mock.resetCalls();
+		getImplementsInterfacesStatementMock.mock.resetCalls();
+	});
+
+	it('should map object types to FEStatements', () => {
+		const objectTypes = {
+			User: {
+				description: 'A user object',
+				isActivated: true,
+				properties: {
+					id: { type: 'ID', description: 'The user id', isActivated: true },
+					name: { type: 'String', isActivated: false },
+				},
+				required: ['id'],
+				typeDirectives: [{ directiveFormat: 'Raw', rawDirective: '@key' }],
+				implementsInterfaces: ['Node'],
+			},
+		};
+
+		getImplementsInterfacesStatementMock.mock.mockImplementationOnce(() => 'implements Node');
+		getDirectivesUsageStatementMock.mock.mockImplementationOnce(() => '@key');
+		joinInlineStatementsMock.mock.mockImplementationOnce(({ statements }) => statements.filter(Boolean).join(' '));
+
+		const result = getObjectLikeTypes({
+			objectTypes,
+			definitionsIdToNameMap,
+			typeKeyword: 'type',
+			getFieldsFunction: ({ fields, requiredFields }) =>
+				Object.entries(fields).map(([name, fieldData]) => ({
+					statement: `${name}: ${fieldData.type}${requiredFields.includes(name) ? '!' : ''}`,
+					description: fieldData.description,
+					isActivated: fieldData.isActivated,
+				})),
+		});
+
+		strictEqual(result.length, 1);
+		deepStrictEqual(result[0], {
+			statement: 'type User implements Node @key',
+			description: 'A user object',
+			isActivated: true,
+			nestedStatements: [
+				{ statement: 'id: ID!', description: 'The user id', isActivated: true },
+				{ statement: 'name: String', description: undefined, isActivated: false },
+			],
+		});
+	});
+
+	it('should map interface types to FEStatements', () => {
+		const interfaceTypes = {
+			Node: {
+				description: 'A node interface',
+				isActivated: true,
+				properties: {
+					id: { type: 'ID', isActivated: true },
+				},
+				required: ['id'],
+				typeDirectives: [],
+				implementsInterfaces: [],
+			},
+		};
+
+		getImplementsInterfacesStatementMock.mock.mockImplementationOnce(() => '');
+		getDirectivesUsageStatementMock.mock.mockImplementationOnce(() => '');
+		joinInlineStatementsMock.mock.mockImplementationOnce(({ statements }) => statements.filter(Boolean).join(' '));
+
+		const result = getObjectLikeTypes({
+			objectTypes: interfaceTypes,
+			definitionsIdToNameMap,
+			typeKeyword: 'interface',
+			getFieldsFunction: ({ fields, requiredFields }) =>
+				Object.entries(fields).map(([name, fieldData]) => ({
+					statement: `${name}: ${fieldData.type}${requiredFields.includes(name) ? '!' : ''}`,
+					description: fieldData.description,
+					isActivated: fieldData.isActivated,
+				})),
+		});
+
+		strictEqual(result.length, 1);
+		deepStrictEqual(result[0], {
+			statement: 'interface Node',
+			description: 'A node interface',
+			isActivated: true,
+			nestedStatements: [{ statement: 'id: ID!', description: undefined, isActivated: true }],
+		});
+	});
+
+	it('should map input types to FEStatements without implements statement', () => {
+		const inputTypes = {
+			UserInput: {
+				description: 'A user input object',
+				isActivated: true,
+				properties: {
+					name: { type: 'String', isActivated: true },
+					age: { type: 'Int', isActivated: false },
+				},
+				required: ['name'],
+				typeDirectives: [],
+			},
+		};
+
+		getImplementsInterfacesStatementMock.mock.mockImplementationOnce(() => '');
+		getDirectivesUsageStatementMock.mock.mockImplementationOnce(() => '');
+		joinInlineStatementsMock.mock.mockImplementationOnce(({ statements }) => statements.filter(Boolean).join(' '));
+
+		const result = getObjectLikeTypes({
+			objectTypes: inputTypes,
+			definitionsIdToNameMap,
+			typeKeyword: 'input',
+			getFieldsFunction: ({ fields, requiredFields }) =>
+				Object.entries(fields).map(([name, fieldData]) => ({
+					statement: `${name}: ${fieldData.type}${requiredFields.includes(name) ? '!' : ''}`,
+					description: fieldData.description,
+					isActivated: fieldData.isActivated,
+				})),
+		});
+
+		strictEqual(result.length, 1);
+		deepStrictEqual(result[0], {
+			statement: 'input UserInput',
+			description: 'A user input object',
+			isActivated: true,
+			nestedStatements: [
+				{ statement: 'name: String!', description: undefined, isActivated: true },
+				{ statement: 'age: Int', description: undefined, isActivated: false },
+			],
+		});
+
+		// verify that getImplementsInterfacesStatementMock was not called for input types
+		strictEqual(getImplementsInterfacesStatementMock.mock.calls.length, 0);
+	});
+});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9576" title="HCK-9576" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9576</a>  Add Interface type FE
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR adds:
- interface types FE
- input types FE

...

## Technical details

The `objectLikeType` mapper is reused for object, input, and interface types, as they are quite similar.
The difference between these types is:
- input types cannot have the "implements interfaces" part
- only the input type fields can have default values

...