### PR TITLE
HCK-9651, HCK-9652, HCK-9659: fix issues related to type selector in GraphQL

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1291,7 +1291,20 @@ making sure that you maintain a proper JSON format.
 									},
 									"options": {
 										"useAllDefinitionsAsSource": true,
-										"includeTargetTypes": true
+										"groupBy": "childType",
+										"includeTargetTypes": {
+											"excludeTypes": [
+												"List",
+												"enum",
+												"input",
+												"scalar",
+												"union",
+												"object",
+												"interface",
+												"union",
+												"directive"
+											]
+										}
 									}
 								}
 							}
@@ -1404,7 +1417,20 @@ making sure that you maintain a proper JSON format.
 									},
 									"options": {
 										"useAllDefinitionsAsSource": true,
-										"includeTargetTypes": true
+										"groupBy": "childType",
+										"includeTargetTypes": {
+											"excludeTypes": [
+												"List",
+												"enum",
+												"input",
+												"scalar",
+												"union",
+												"object",
+												"interface",
+												"union",
+												"directive"
+											]
+										}
 									}
 								}
 							}
@@ -1517,7 +1543,20 @@ making sure that you maintain a proper JSON format.
 									},
 									"options": {
 										"useAllDefinitionsAsSource": true,
-										"includeTargetTypes": true
+										"groupBy": "childType",
+										"includeTargetTypes": {
+											"excludeTypes": [
+												"List",
+												"enum",
+												"input",
+												"scalar",
+												"union",
+												"object",
+												"interface",
+												"union",
+												"directive"
+											]
+										}
 									}
 								}
 							}
@@ -1630,7 +1669,20 @@ making sure that you maintain a proper JSON format.
 									},
 									"options": {
 										"useAllDefinitionsAsSource": true,
-										"includeTargetTypes": true
+										"groupBy": "childType",
+										"includeTargetTypes": {
+											"excludeTypes": [
+												"List",
+												"enum",
+												"input",
+												"scalar",
+												"union",
+												"object",
+												"interface",
+												"union",
+												"directive"
+											]
+										}
 									}
 								}
 							}
@@ -1743,7 +1795,20 @@ making sure that you maintain a proper JSON format.
 									},
 									"options": {
 										"useAllDefinitionsAsSource": true,
-										"includeTargetTypes": true
+										"groupBy": "childType",
+										"includeTargetTypes": {
+											"excludeTypes": [
+												"List",
+												"enum",
+												"input",
+												"scalar",
+												"union",
+												"object",
+												"interface",
+												"union",
+												"directive"
+											]
+										}
 									}
 								}
 							}
@@ -1856,7 +1921,20 @@ making sure that you maintain a proper JSON format.
 									},
 									"options": {
 										"useAllDefinitionsAsSource": true,
-										"includeTargetTypes": true
+										"groupBy": "childType",
+										"includeTargetTypes": {
+											"excludeTypes": [
+												"List",
+												"enum",
+												"input",
+												"scalar",
+												"union",
+												"object",
+												"interface",
+												"union",
+												"directive"
+											]
+										}
 									}
 								}
 							}
@@ -1970,7 +2048,20 @@ making sure that you maintain a proper JSON format.
 									},
 									"options": {
 										"useAllDefinitionsAsSource": true,
-										"includeTargetTypes": true
+										"groupBy": "childType",
+										"includeTargetTypes": {
+											"excludeTypes": [
+												"List",
+												"enum",
+												"input",
+												"scalar",
+												"union",
+												"object",
+												"interface",
+												"union",
+												"directive"
+											]
+										}
 									}
 								}
 							}
@@ -2093,7 +2184,20 @@ making sure that you maintain a proper JSON format.
 									},
 									"options": {
 										"useAllDefinitionsAsSource": true,
-										"includeTargetTypes": true
+										"groupBy": "childType",
+										"includeTargetTypes": {
+											"excludeTypes": [
+												"List",
+												"enum",
+												"input",
+												"scalar",
+												"union",
+												"object",
+												"interface",
+												"union",
+												"directive"
+											]
+										}
 									}
 								}
 							}
@@ -2216,7 +2320,20 @@ making sure that you maintain a proper JSON format.
 									},
 									"options": {
 										"useAllDefinitionsAsSource": true,
-										"includeTargetTypes": true
+										"groupBy": "childType",
+										"includeTargetTypes": {
+											"excludeTypes": [
+												"List",
+												"enum",
+												"input",
+												"scalar",
+												"union",
+												"object",
+												"interface",
+												"union",
+												"directive"
+											]
+										}
 									}
 								}
 							}
@@ -2339,7 +2456,20 @@ making sure that you maintain a proper JSON format.
 									},
 									"options": {
 										"useAllDefinitionsAsSource": true,
-										"includeTargetTypes": true
+										"groupBy": "childType",
+										"includeTargetTypes": {
+											"excludeTypes": [
+												"List",
+												"enum",
+												"input",
+												"scalar",
+												"union",
+												"object",
+												"interface",
+												"union",
+												"directive"
+											]
+										}
 									}
 								}
 							}
@@ -2447,7 +2577,20 @@ making sure that you maintain a proper JSON format.
 									},
 									"options": {
 										"useAllDefinitionsAsSource": true,
-										"includeTargetTypes": true
+										"groupBy": "childType",
+										"includeTargetTypes": {
+											"excludeTypes": [
+												"List",
+												"enum",
+												"input",
+												"scalar",
+												"union",
+												"object",
+												"interface",
+												"union",
+												"directive"
+											]
+										}
 									}
 								}
 							}
@@ -2554,7 +2697,20 @@ making sure that you maintain a proper JSON format.
 									},
 									"options": {
 										"useAllDefinitionsAsSource": true,
-										"includeTargetTypes": true
+										"groupBy": "childType",
+										"includeTargetTypes": {
+											"excludeTypes": [
+												"List",
+												"enum",
+												"input",
+												"scalar",
+												"union",
+												"object",
+												"interface",
+												"union",
+												"directive"
+											]
+										}
 									}
 								}
 							}

--- a/test/forward_engineering/mappers/arguments.spec.js
+++ b/test/forward_engineering/mappers/arguments.spec.js
@@ -159,7 +159,7 @@ describe('getArguments', () => {
 		strictEqual(result, '(arg1: String, arg2: Int)');
 	});
 
-	it.skip('should return formatted arguments if descriptions are present', () => {
+	it('should return formatted arguments if descriptions are present', () => {
 		const graphqlArguments = [
 			{ name: 'arg1', type: 'String', description: 'Argument description 1' },
 			{ name: 'arg2', type: 'Int', description: 'Argument description 2' },
@@ -176,7 +176,7 @@ describe('getArguments', () => {
 		strictEqual(result, '(arg1: String, arg2: Int)');
 	});
 
-	it.skip("should skip arguments which don't have name or type or both", () => {
+	it("should skip arguments which don't have name or type or both", () => {
 		const graphqlArguments = [
 			{ type: 'String' }, // missing name
 			{ name: 'arg2' }, // missing type


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9651" title="HCK-9651" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9651</a>  "List" should not be in the list of Types for Argument (as defined by Cardinality and nullability property)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

- Added enhanced configurations for arguments type properties, supported with this [PR](https://github.com/hackolade/studio/pull/2534)
...