### PR TITLE
HCK-9723: fix generation directive locations in FE scrip when location has falsy value

### DIFF
--- a/forward_engineering/mappers/directives.js
+++ b/forward_engineering/mappers/directives.js
@@ -16,7 +16,7 @@ const UNKNOWN_LOCATION = 'UNKNOWN_LOCATION';
  */
 function mapDirectiveLocations({ directiveLocations = {} }) {
 	const directiveLocationsString = Object.keys(directiveLocations)
-		.filter(location => location !== 'id')
+		.filter(location => location !== 'id' && directiveLocations[location]) // should not include id and have truthy value
 		.map(locations => DIRECTIVE_LOCATIONS[locations] || UNKNOWN_LOCATION)
 		.join(' | ');
 

--- a/test/forward_engineering/mappers/directives.spec.js
+++ b/test/forward_engineering/mappers/directives.spec.js
@@ -36,6 +36,12 @@ describe('mapDirectiveLocations', () => {
 		strictEqual(result, 'QUERY');
 	});
 
+	it('should skip locations that have falsy values in directive locations object', () => {
+		const directiveLocations = { field: true, query: false };
+		const result = mapDirectiveLocations({ directiveLocations });
+		strictEqual(result, 'FIELD');
+	});
+
 	it('should map directive locations to a string', () => {
 		const directiveLocations = { field: true, query: true };
 		const result = mapDirectiveLocations({ directiveLocations });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9723" title="HCK-9723" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9723</a>  [GraphQL][FE][Directives] Uncheck of once checked 'Directive location' does not change FE script (still looks like checked)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

- Added filter or falsy values in directive locations object

...

