### PR TITLE
HCK-9757: hide implement interfaces on references

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -3745,6 +3745,10 @@ making sure that you maintain a proper JSON format.
 								"buttons": ["contactSupport", "ok"]
 							}
 						}
+					},
+					"dependency": {
+						"key": "ref",
+						"exist": false
 					}
 				}
 			],
@@ -3798,6 +3802,10 @@ making sure that you maintain a proper JSON format.
 								"buttons": ["contactSupport", "ok"]
 							}
 						}
+					},
+					"dependency": {
+						"key": "ref",
+						"exist": false
 					}
 				}
 			]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9757" title="HCK-9757" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9757</a>  Implement interface should not be available at Field level
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

The "Implement interfaces" tab should be available only for the root `object` and `interface` types.