### PR TITLE
Disable unsupported RE options

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,21 +18,21 @@
             "enableReverseEngineering": {
                 "jsonDocument": {
                     "entities": false,
-                    "model_definitions": true
+                    "model_definitions": false
                 },
                 "jsonSchema": {
                     "entities": false,
-                    "model_definitions": true
+                    "model_definitions": false
                 },
                 "ddl": {
                     "entities": false,
-                    "model_definitions": true
+                    "model_definitions": false
                 },
                 "xsd": {
                     "entities": false,
-                    "model_definitions": true
+                    "model_definitions": false
                 },
-                "plugin": true
+                "plugin": false
             },
             "disableDenormalization": true,
             "enableForwardEngineering": {


### PR DESCRIPTION
## Content

This pull request disables all Reverse Engineering options.
The RE functionality for GraphQL schemas has not been implemented yet.
Additionally, for other RE options, we need to implement normalization that creates references between normalized items before enabling them.