### PR TITLE
HCK-9755: enum value description should be textarea input

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -713,7 +713,10 @@ making sure that you maintain a proper JSON format.
 						{
 							"propertyName": "Description",
 							"propertyKeyword": "description",
-							"propertyType": "text"
+							"propertyType": "details",
+							"template": "textarea",
+							"propertyTooltip": "Enter description",
+							"markdown": true
 						},
 						{
 							"propertyName": "Directives",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9755" title="HCK-9755" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9755</a>  Description of Enum VALUES should be text area (all descriptions should)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
