### PR TITLE
HCK-9800: do not include schema custom root type names the root type is empty

### DIFF
--- a/forward_engineering/mappers/rootTypes.js
+++ b/forward_engineering/mappers/rootTypes.js
@@ -17,8 +17,8 @@ const { getRootTypeFields } = require('./fields');
  */
 function getSchemaRootTypeStatements({ containers = [], definitionsIdToNameMap }) {
 	const rootTypeNames = getRootTypeNames({ containers });
-	const rootSchemaStatement = getRootSchemaStatement({ rootTypeNames });
-	const rootTypes = getRootTypes({ containers, rootTypeNames, definitionsIdToNameMap });
+	const rootTypes = getRootTypes({ containers, rootTypeNames, definitionsIdToNameMap }).filter(Boolean);
+	const rootSchemaStatement = getRootSchemaStatement({ rootTypeNames, rootTypes });
 
 	return [rootSchemaStatement, ...rootTypes]
 		.filter(Boolean)
@@ -29,27 +29,30 @@ function getSchemaRootTypeStatements({ containers = [], definitionsIdToNameMap }
 /**
  * Gets the root schema statement.
  * If all root types have default values, return null.
+ * If at least one root type does not have a default value, return the root schema statement.
+ * If the root type is not present in the root types, do not include it in the root schema statement.
  *
  * @param {Object} param0
  * @param {RootTypeNamesParameter} param0.rootTypeNames - The root type names.
+ * @param {FEStatement[]} param0.rootTypes - The root types.
  * @returns {FEStatement | null} - The root schema statement or null if all root types have default values.
  */
-function getRootSchemaStatement({ rootTypeNames }) {
-	const { query, mutation, subscription } = rootTypeNames;
+function getRootSchemaStatement({ rootTypeNames, rootTypes }) {
+	const rootTypeMap = {
+		query: QUERY_ROOT_TYPE,
+		mutation: MUTATION_ROOT_TYPE,
+		subscription: SUBSCRIPTION_ROOT_TYPE,
+	};
 
-	const nestedStatements = [];
+	const nestedStatements = Object.entries(rootTypeMap).reduce((acc, [key, defaultValue]) => {
+		const isDefaultRootTypeNameHasDefaultValue = rootTypeNames[key] === defaultValue;
+		const isRootTypePresent = rootTypes.some(rootType => rootType.statement.includes(rootTypeNames[key]));
 
-	if (query !== QUERY_ROOT_TYPE) {
-		nestedStatements.push({ statement: `query: ${query}` });
-	}
-
-	if (mutation !== MUTATION_ROOT_TYPE) {
-		nestedStatements.push({ statement: `mutation: ${mutation}` });
-	}
-
-	if (subscription !== SUBSCRIPTION_ROOT_TYPE) {
-		nestedStatements.push({ statement: `subscription: ${subscription}` });
-	}
+		if (!isDefaultRootTypeNameHasDefaultValue && isRootTypePresent) {
+			acc.push({ statement: `${key}: ${rootTypeNames[key]}` });
+		}
+		return acc;
+	}, []);
 
 	if (nestedStatements.length === 0) {
 		return null;

--- a/test/forward_engineering/mappers/rootTypes.spec.js
+++ b/test/forward_engineering/mappers/rootTypes.spec.js
@@ -86,7 +86,12 @@ describe('getRootSchemaStatement', () => {
 			mutation: 'Mutation',
 			subscription: 'Subscription',
 		};
-		const result = getRootSchemaStatement({ rootTypeNames });
+		const rootTypes = [
+			{ statement: 'type Query' },
+			{ statement: 'type Mutation' },
+			{ statement: 'type Subscription' },
+		];
+		const result = getRootSchemaStatement({ rootTypeNames, rootTypes });
 		strictEqual(result, null);
 	});
 
@@ -96,11 +101,41 @@ describe('getRootSchemaStatement', () => {
 			mutation: 'Mutation',
 			subscription: 'CustomSubscription',
 		};
-		const result = getRootSchemaStatement({ rootTypeNames });
+		const rootTypes = [
+			{ statement: 'type CustomQuery' },
+			{ statement: 'type Mutation' },
+			{ statement: 'type CustomSubscription' },
+		];
+		const result = getRootSchemaStatement({ rootTypeNames, rootTypes });
 		deepStrictEqual(result, {
 			statement: 'schema',
 			nestedStatements: [{ statement: 'query: CustomQuery' }, { statement: 'subscription: CustomSubscription' }],
 		});
+	});
+
+	it('should return schema statement with only present custom root types', () => {
+		const rootTypeNames = {
+			query: 'CustomQuery',
+			mutation: 'Mutation',
+			subscription: 'CustomSubscription',
+		};
+		const rootTypes = [{ statement: 'type CustomQuery' }, { statement: 'type Mutation' }];
+		const result = getRootSchemaStatement({ rootTypeNames, rootTypes });
+		deepStrictEqual(result, {
+			statement: 'schema',
+			nestedStatements: [{ statement: 'query: CustomQuery' }],
+		});
+	});
+
+	it('should return null if no custom root types are present', () => {
+		const rootTypeNames = {
+			query: 'CustomQuery',
+			mutation: 'Mutation',
+			subscription: 'CustomSubscription',
+		};
+		const rootTypes = [{ statement: 'type Mutation' }];
+		const result = getRootSchemaStatement({ rootTypeNames, rootTypes });
+		strictEqual(result, null);
 	});
 });
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9800" title="HCK-9800" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9800</a>  [FE][GraphQL] Unnecessary Mutation/Subscription forwarding in case if no operation of that type defained
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

In this PR, I am updating the logic for the `schema` statement which allows renaming root types to custom names.
Previously, a renamed root type was included in the `schema` even if the type itself was empty, it could lead to an error in the GraphQL validator.
With this update, empty root types are no longer included in the `schema` statement, even if they have custom names.