### PR TITLE
HCK-9745: add schema version header

### DIFF
--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -6,6 +6,7 @@ const validationHelper = require('./helpers/schemaValidationHelper');
 const { getTypeDefinitionStatements } = require('./mappers/typeDefinitions');
 const { generateIdToNameMap } = require('./helpers/generateIdToNameMap');
 const { getSchemaRootTypeStatements } = require('./mappers/rootTypes');
+const { getSchemaVersionHeader } = require('./mappers/schemaVersionHeader');
 
 module.exports = {
 	/**
@@ -19,13 +20,16 @@ module.exports = {
 			const modelDefinitions = JSON.parse(data.modelDefinitions);
 			const definitionsIdToNameMap = generateIdToNameMap(modelDefinitions.properties);
 
+			const schemaVersionHeader = getSchemaVersionHeader({ schemaVersion: data.modelData[0]?.version });
 			const rootTypeStatements = getSchemaRootTypeStatements({
 				containers: data.containers,
 				definitionsIdToNameMap,
 			});
 			const typeDefinitionStatements = getTypeDefinitionStatements({ modelDefinitions, definitionsIdToNameMap });
 
-			const schemaScript = [rootTypeStatements, typeDefinitionStatements].filter(Boolean).join('\n\n');
+			const schemaScript = [schemaVersionHeader, rootTypeStatements, typeDefinitionStatements]
+				.filter(Boolean)
+				.join('\n\n');
 
 			cb(null, schemaScript);
 		} catch (err) {

--- a/forward_engineering/helpers/commentLinesHelper.js
+++ b/forward_engineering/helpers/commentLinesHelper.js
@@ -1,11 +1,13 @@
 /**
- * Comments out a GraphQL statement if it is deactivated.
+ * Adds comment markers to each line of a GraphQL statement.
+ * This function takes a GraphQL statement and prepends a '#' character
+ * to each line, commenting out the entire statement.
  *
  * @param {Object} param0
  * @param {string} param0.statement - The GraphQL statement to comment out
  * @returns {string} - Commented out statement
  */
-function commentOutDeactivatedRootFEStatement({ statement }) {
+function commentLines({ statement }) {
 	const commentedStatement = statement
 		.split('\n')
 		.map(line => `# ${line}`)
@@ -15,5 +17,5 @@ function commentOutDeactivatedRootFEStatement({ statement }) {
 }
 
 module.exports = {
-	commentOutDeactivatedRootFEStatement,
+	commentLines,
 };

--- a/forward_engineering/helpers/feStatementFormatHelper.js
+++ b/forward_engineering/helpers/feStatementFormatHelper.js
@@ -2,7 +2,7 @@
  * @import { FEStatement } from "../types/types"
  */
 
-const { commentOutDeactivatedRootFEStatement } = require('./deactivatedItemsHelper');
+const { commentLines } = require('./commentLinesHelper');
 const { getStatementDescription } = require('./descriptionsHelper');
 const { addIndentToStatement } = require('./feStatementIndentHelper');
 
@@ -40,7 +40,7 @@ function formatFEStatement({ feStatement }) {
 	});
 
 	if (!isActivated) {
-		result = commentOutDeactivatedRootFEStatement({ statement: result, isActivated });
+		result = commentLines({ statement: result });
 	}
 
 	return result;

--- a/forward_engineering/mappers/schemaVersionHeader.js
+++ b/forward_engineering/mappers/schemaVersionHeader.js
@@ -1,0 +1,24 @@
+const { commentLines } = require('../helpers/commentLinesHelper');
+
+/**
+ * Generates a commented header containing the schema version and the generation date.
+ *
+ * @param {Object} param0
+ * @param {string} param0.schemaVersion - The version of the schema.
+ * @returns {string} - The commented header containing the schema version and generation date.
+ */
+function getSchemaVersionHeader({ schemaVersion }) {
+	let statement = '';
+	const trimmedSchemaVersion = schemaVersion?.trim();
+	if (trimmedSchemaVersion) {
+		statement = `Schema Version: ${trimmedSchemaVersion}\n`;
+	}
+	const localDate = new Date().toLocaleString();
+	statement += `Generated on: ${localDate}`;
+
+	return commentLines({ statement });
+}
+
+module.exports = {
+	getSchemaVersionHeader,
+};

--- a/properties_pane/defaultData.json
+++ b/properties_pane/defaultData.json
@@ -2,7 +2,8 @@
 	"model": {
 		"modelName": "New GraphQL model",
 		"dbVersion": "",
-		"dbVendor": "GraphQL"
+		"dbVendor": "GraphQL",
+		"version": "1.0.0"
 	},
 	"container": {
 		"name": "NewGraph",

--- a/properties_pane/model_level/modelLevelConfig.json
+++ b/properties_pane/model_level/modelLevelConfig.json
@@ -141,7 +141,8 @@ making sure that you maintain a proper JSON format.
 				"propertyTooltip": "DB version",
 				"propertyType": "select",
 				"options": [],
-				"disabledOption": true
+				"disabledOption": true,
+				"hidden": true
 			},
 			{
 				"propertyName": "Comments",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9745" title="HCK-9745" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9745</a>  Include a header comment at the top of the file specifying the version of the schema and the date of generation.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR introduces a commented-out header to the FE-d schema. The header includes the schema version and the date of generation.