### PR TITLE
HCK-9837, HCK-9867: switch to container level FE

### DIFF
--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -10,19 +10,22 @@ const { getSchemaVersionHeader } = require('./mappers/schemaVersionHeader');
 
 module.exports = {
 	/**
-	 * Generates the model FE script for the given data.
-	 * @param {ModelScriptFEData} data - The data for generating the model script.
+	 * Generates the container FE script for the given data.
+	 *
+	 * @param {ModelScriptFEData} data - The data for generating the container script.
 	 * @param {Logger} logger - The logger for logging errors.
 	 * @param {GenerateModelScriptCallback} cb - The callback function.
 	 */
-	generateModelScript(data, logger, cb) {
+	generateContainerScript(data, logger, cb) {
 		try {
 			const modelDefinitions = JSON.parse(data.modelDefinitions);
 			const definitionsIdToNameMap = generateIdToNameMap(modelDefinitions.properties);
 
 			const schemaVersionHeader = getSchemaVersionHeader({ schemaVersion: data.modelData[0]?.version });
 			const rootTypeStatements = getSchemaRootTypeStatements({
-				containers: data.containers,
+				containerProperties: data.containerData,
+				entitiesJsonSchema: data.jsonSchema,
+				entityProperties: data.entityData,
 				definitionsIdToNameMap,
 			});
 			const typeDefinitionStatements = getTypeDefinitionStatements({ modelDefinitions, definitionsIdToNameMap });
@@ -40,6 +43,7 @@ module.exports = {
 
 	/**
 	 * Validates the given script data.
+	 *
 	 * @param {Object} data - The data for validation.
 	 * @param {string} data.script - The script to be validated.
 	 * @param {Object} data.targetScriptOptions - Options for the target script.

--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -1,5 +1,5 @@
 /**
- * @import { ModelScriptFEData, Logger, GenerateModelScriptCallback } from "./types/types"
+ * @import { ContainerLevelScriptFEData, Logger, GenerateContainerLevelScriptCallback } from "./types/types"
  */
 
 const validationHelper = require('./helpers/schemaValidationHelper');
@@ -12,9 +12,9 @@ module.exports = {
 	/**
 	 * Generates the container FE script for the given data.
 	 *
-	 * @param {ModelScriptFEData} data - The data for generating the container script.
+	 * @param {ContainerLevelScriptFEData} data - The data for generating the container script.
 	 * @param {Logger} logger - The logger for logging errors.
-	 * @param {GenerateModelScriptCallback} cb - The callback function.
+	 * @param {GenerateContainerLevelScriptCallback} cb - The callback function.
 	 */
 	generateContainerScript(data, logger, cb) {
 		try {

--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -7,9 +7,9 @@
 	"keepRequiredOnArrayItem": true,
 	"level": {
 		"entity": false,
-		"container": false,
-		"model": true
+		"container": true,
+		"model": false
 	},
 	"mode": "graphqlschema",
-	"isApiSchema": true
+	"isApiSchema": false
 }

--- a/forward_engineering/mappers/rootTypes.js
+++ b/forward_engineering/mappers/rootTypes.js
@@ -1,5 +1,5 @@
 /**
- * @import { FEStatement, IdToNameMap, RootTypeNamesParameter, ContainerData } from "../types/types"
+ * @import { FEStatement, IdToNameMap, RootTypeNamesParameter, EntityIdToJsonSchemaMap, EntityIdToPropertiesMap } from "../types/types"
  */
 
 const { QUERY_ROOT_TYPE, MUTATION_ROOT_TYPE, SUBSCRIPTION_ROOT_TYPE } = require('../constants/feScriptConstants');
@@ -9,13 +9,14 @@ const { getDirectivesUsageStatement } = require('./directiveUsageStatements');
 const { getRootTypeFields } = require('./fields');
 
 /**
- * Gets root schema statement the root type statements.
- * If all root types have default values, root schema statement is not returned.
+ * Gets root schema statement and the root type statements.
  *
  * @param {Object} param0
- * @param {ContainerData} param0.container - The container properties.
+ * @param {Object[]} param0.containerProperties - The container properties by tab.
+ * @param {EntityIdToJsonSchemaMap} param0.entitiesJsonSchema - The entities JSON schema, where the key is the entity id and the value is the entity JSON schema.
+ * @param {EntityIdToPropertiesMap} param0.entityProperties - The entity properties by entity id.
  * @param {IdToNameMap} param0.definitionsIdToNameMap - The definitions id to name map.
- * @returns {FEStatement[]} - The root type statements.
+ * @returns {string} - The formatted root type statements.
  */
 function getSchemaRootTypeStatements({
 	containerProperties,
@@ -40,13 +41,13 @@ function getSchemaRootTypeStatements({
 
 /**
  * Gets the root schema statement.
- * If all root types have default values, return null.
- * If at least one root type does not have a default value, return the root schema statement.
+ * If all root types are empty, return null, to trigger validation error that we are referencing non-existing root types.
  * If the root type is not present in the root types, do not include it in the root schema statement.
  *
  * @param {Object} param0
  * @param {RootTypeNamesParameter} param0.rootTypeNames - The root type names.
  * @param {FEStatement[]} param0.rootTypes - The root types.
+ * @param {Object[]} param0.containerProperties - The container properties.
  * @returns {FEStatement | null} - The root schema statement or null if all root types have default values.
  */
 function getRootSchemaStatement({ rootTypeNames, rootTypes, containerProperties }) {
@@ -80,10 +81,10 @@ function getRootSchemaStatement({ rootTypeNames, rootTypes, containerProperties 
 
 /**
  * Gets the root type names.
- * Iterate over the containers and get the root type names.
+ * Return the default root type names or the custom root type names if they are present in the container properties.
  *
  * @param {Object} param0
- * @param {ContainerData} param0.container - The containers.
+ * @param {Object[]} param0.containerProperties - The container properties.
  * @returns {RootTypeNamesParameter} - The root type names.
  */
 function getRootTypeNames({ containerProperties }) {
@@ -93,7 +94,7 @@ function getRootTypeNames({ containerProperties }) {
 		subscription: SUBSCRIPTION_ROOT_TYPE,
 	};
 
-	const containerRootTypesPropertyValue = containerProperties?.containerData?.[0]?.schemaRootTypes;
+	const containerRootTypesPropertyValue = containerProperties?.[0]?.schemaRootTypes;
 
 	if (containerRootTypesPropertyValue) {
 		const { rootQuery, rootMutation, rootSubscription } = containerRootTypesPropertyValue;
@@ -120,12 +121,12 @@ function getRootTypeNames({ containerProperties }) {
 
 /**
  * Gets the root types.
- * Iterate over the containers and get the root types.
+ * Iterate over the entities and get the root types.
  * For each root type, get the nested statements composed of the fields of the entities with the operation type equal to the root type.
- * If there are no entities with the operation type equal to the root type, return null.
  *
  * @param {Object} param0
- * @param {ContainerData[]} param0.containers - The containers.
+ * @param {EntityIdToJsonSchemaMap} param0.entitiesJsonSchema - The entities JSON schema.
+ * @param {EntityIdToPropertiesMap} param0.entityProperties - The entity properties.
  * @param {RootTypeNamesParameter} param0.rootTypeNames - The root type names.
  * @param {IdToNameMap} param0.definitionsIdToNameMap - The definitions id to name map.
  * @returns {FEStatement[]} - The root types.
@@ -162,12 +163,13 @@ function getRootTypes({ entitiesJsonSchema, entityProperties, rootTypeNames, def
 
 /**
  * Gets the root type.
- * Iterate over the containers and get the root type.
+ * Iterate over the entities and get the root type.
  * For each root type, get the nested statements composed of the fields of the entities with the operation type equal to the root type.
  * If there are no entities with the operation type equal to the root type, return null.
  *
  * @param {Object} param0
- * @param {ContainerData[]} param0.containers - The containers.
+ * @param {EntityIdToJsonSchemaMap} param0.entitiesJsonSchema - The entities JSON schema.
+ * @param {EntityIdToPropertiesMap} param0.entityProperties - The entity properties.
  * @param {string} param0.rootTypeName - The root type name.
  * @param {IdToNameMap} param0.definitionsIdToNameMap - The definitions id to name map.
  * @param {string} param0.rootType - The root type.

--- a/forward_engineering/mappers/rootTypes.js
+++ b/forward_engineering/mappers/rootTypes.js
@@ -74,7 +74,7 @@ function getRootSchemaStatement({ rootTypeNames, rootTypes, containerProperties 
 
 	return {
 		statement: joinInlineStatements({ statements: ['schema', schemaDirectives] }),
-		description: containerProperties?.[0]?.description,
+		description: containerProperties?.[0]?.description || '',
 		nestedStatements,
 	};
 }

--- a/forward_engineering/mappers/rootTypes.js
+++ b/forward_engineering/mappers/rootTypes.js
@@ -4,6 +4,8 @@
 
 const { QUERY_ROOT_TYPE, MUTATION_ROOT_TYPE, SUBSCRIPTION_ROOT_TYPE } = require('../constants/feScriptConstants');
 const { formatFEStatement } = require('../helpers/feStatementFormatHelper');
+const { joinInlineStatements } = require('../helpers/feStatementJoinHelper');
+const { getDirectivesUsageStatement } = require('./directiveUsageStatements');
 const { getRootTypeFields } = require('./fields');
 
 /**
@@ -11,14 +13,24 @@ const { getRootTypeFields } = require('./fields');
  * If all root types have default values, root schema statement is not returned.
  *
  * @param {Object} param0
- * @param {ContainerData[]} param0.containers - The containers.
+ * @param {ContainerData} param0.container - The container properties.
  * @param {IdToNameMap} param0.definitionsIdToNameMap - The definitions id to name map.
  * @returns {FEStatement[]} - The root type statements.
  */
-function getSchemaRootTypeStatements({ containers = [], definitionsIdToNameMap }) {
-	const rootTypeNames = getRootTypeNames({ containers });
-	const rootTypes = getRootTypes({ containers, rootTypeNames, definitionsIdToNameMap }).filter(Boolean);
-	const rootSchemaStatement = getRootSchemaStatement({ rootTypeNames, rootTypes });
+function getSchemaRootTypeStatements({
+	containerProperties,
+	entitiesJsonSchema,
+	entityProperties,
+	definitionsIdToNameMap,
+}) {
+	const rootTypeNames = getRootTypeNames({ containerProperties });
+	const rootTypes = getRootTypes({
+		entitiesJsonSchema,
+		entityProperties,
+		rootTypeNames,
+		definitionsIdToNameMap,
+	}).filter(Boolean);
+	const rootSchemaStatement = getRootSchemaStatement({ rootTypeNames, rootTypes, containerProperties });
 
 	return [rootSchemaStatement, ...rootTypes]
 		.filter(Boolean)
@@ -37,7 +49,7 @@ function getSchemaRootTypeStatements({ containers = [], definitionsIdToNameMap }
  * @param {FEStatement[]} param0.rootTypes - The root types.
  * @returns {FEStatement | null} - The root schema statement or null if all root types have default values.
  */
-function getRootSchemaStatement({ rootTypeNames, rootTypes }) {
+function getRootSchemaStatement({ rootTypeNames, rootTypes, containerProperties }) {
 	const rootTypeMap = {
 		query: QUERY_ROOT_TYPE,
 		mutation: MUTATION_ROOT_TYPE,
@@ -45,10 +57,9 @@ function getRootSchemaStatement({ rootTypeNames, rootTypes }) {
 	};
 
 	const nestedStatements = Object.entries(rootTypeMap).reduce((acc, [key, defaultValue]) => {
-		const isDefaultRootTypeNameHasDefaultValue = rootTypeNames[key] === defaultValue;
 		const isRootTypePresent = rootTypes.some(rootType => rootType.statement.includes(rootTypeNames[key]));
 
-		if (!isDefaultRootTypeNameHasDefaultValue && isRootTypePresent) {
+		if (isRootTypePresent) {
 			acc.push({ statement: `${key}: ${rootTypeNames[key]}` });
 		}
 		return acc;
@@ -58,8 +69,11 @@ function getRootSchemaStatement({ rootTypeNames, rootTypes }) {
 		return null;
 	}
 
+	const schemaDirectives = getDirectivesUsageStatement({ directives: containerProperties?.[0]?.graphDirectives });
+
 	return {
-		statement: 'schema',
+		statement: joinInlineStatements({ statements: ['schema', schemaDirectives] }),
+		description: containerProperties?.[0]?.description,
 		nestedStatements,
 	};
 }
@@ -69,39 +83,37 @@ function getRootSchemaStatement({ rootTypeNames, rootTypes }) {
  * Iterate over the containers and get the root type names.
  *
  * @param {Object} param0
- * @param {ContainerData[]} param0.containers - The containers.
+ * @param {ContainerData} param0.container - The containers.
  * @returns {RootTypeNamesParameter} - The root type names.
  */
-function getRootTypeNames({ containers = [] }) {
+function getRootTypeNames({ containerProperties }) {
 	const rootContainersNames = {
 		query: QUERY_ROOT_TYPE,
 		mutation: MUTATION_ROOT_TYPE,
 		subscription: SUBSCRIPTION_ROOT_TYPE,
 	};
 
-	containers.forEach(container => {
-		const containerRootTypesPropertyValue = container.containerData?.[0]?.schemaRootTypes;
+	const containerRootTypesPropertyValue = containerProperties?.containerData?.[0]?.schemaRootTypes;
 
-		if (containerRootTypesPropertyValue) {
-			const { rootQuery, rootMutation, rootSubscription } = containerRootTypesPropertyValue;
+	if (containerRootTypesPropertyValue) {
+		const { rootQuery, rootMutation, rootSubscription } = containerRootTypesPropertyValue;
 
-			const trimmedRootQuery = rootQuery?.trim() || '';
-			const trimmedRootMutation = rootMutation?.trim() || '';
-			const trimmedRootSubscription = rootSubscription?.trim() || '';
+		const trimmedRootQuery = rootQuery?.trim() || '';
+		const trimmedRootMutation = rootMutation?.trim() || '';
+		const trimmedRootSubscription = rootSubscription?.trim() || '';
 
-			if (trimmedRootQuery && trimmedRootQuery !== rootContainersNames.query) {
-				rootContainersNames.query = trimmedRootQuery;
-			}
-
-			if (trimmedRootMutation && trimmedRootMutation !== rootContainersNames.mutation) {
-				rootContainersNames.mutation = trimmedRootMutation;
-			}
-
-			if (trimmedRootSubscription && trimmedRootSubscription !== rootContainersNames.subscription) {
-				rootContainersNames.subscription = trimmedRootSubscription;
-			}
+		if (trimmedRootQuery && trimmedRootQuery !== rootContainersNames.query) {
+			rootContainersNames.query = trimmedRootQuery;
 		}
-	});
+
+		if (trimmedRootMutation && trimmedRootMutation !== rootContainersNames.mutation) {
+			rootContainersNames.mutation = trimmedRootMutation;
+		}
+
+		if (trimmedRootSubscription && trimmedRootSubscription !== rootContainersNames.subscription) {
+			rootContainersNames.subscription = trimmedRootSubscription;
+		}
+	}
 
 	return rootContainersNames;
 }
@@ -118,14 +130,27 @@ function getRootTypeNames({ containers = [] }) {
  * @param {IdToNameMap} param0.definitionsIdToNameMap - The definitions id to name map.
  * @returns {FEStatement[]} - The root types.
  */
-function getRootTypes({ containers, rootTypeNames, definitionsIdToNameMap }) {
+function getRootTypes({ entitiesJsonSchema, entityProperties, rootTypeNames, definitionsIdToNameMap }) {
 	const { query, mutation, subscription } = rootTypeNames;
 
 	const rootTypes = [
-		getRootType({ containers, rootTypeName: query, definitionsIdToNameMap, rootType: QUERY_ROOT_TYPE }),
-		getRootType({ containers, rootTypeName: mutation, definitionsIdToNameMap, rootType: MUTATION_ROOT_TYPE }),
 		getRootType({
-			containers,
+			entitiesJsonSchema,
+			entityProperties,
+			rootTypeName: query,
+			definitionsIdToNameMap,
+			rootType: QUERY_ROOT_TYPE,
+		}),
+		getRootType({
+			entitiesJsonSchema,
+			entityProperties,
+			rootTypeName: mutation,
+			definitionsIdToNameMap,
+			rootType: MUTATION_ROOT_TYPE,
+		}),
+		getRootType({
+			entitiesJsonSchema,
+			entityProperties,
 			rootTypeName: subscription,
 			definitionsIdToNameMap,
 			rootType: SUBSCRIPTION_ROOT_TYPE,
@@ -148,33 +173,32 @@ function getRootTypes({ containers, rootTypeNames, definitionsIdToNameMap }) {
  * @param {string} param0.rootType - The root type.
  * @returns {FEStatement | null} - The root type or null if there are no entities with the operation type equal to the root type.
  */
-function getRootType({ containers, rootTypeName, definitionsIdToNameMap, rootType }) {
+function getRootType({ entitiesJsonSchema, entityProperties, rootTypeName, definitionsIdToNameMap, rootType }) {
 	const rootTypeNestedStatements = [];
-	containers.forEach(container => {
-		Object.entries(container.jsonSchema).forEach(([entityId, entityJson]) => {
-			const entityOperationType = container.entityData[entityId]?.[0]?.operationType;
-			if (entityOperationType !== rootType) {
-				return;
+
+	Object.entries(entitiesJsonSchema).forEach(([entityId, entityJson]) => {
+		const entityOperationType = entityProperties[entityId]?.[0]?.operationType;
+		if (entityOperationType !== rootType) {
+			return;
+		}
+
+		const entityData = JSON.parse(entityJson);
+		const entityFields = getRootTypeFields({
+			fields: entityData.properties,
+			requiredFields: entityData.required,
+			definitionsIdToNameMap,
+		}).map(field => {
+			if (entityData.isActivated === false) {
+				// If the entity is not activated, set the field as not activated
+				return {
+					...field,
+					isActivated: false,
+				};
 			}
-
-			const entityData = JSON.parse(entityJson);
-			const entityFields = getRootTypeFields({
-				fields: entityData.properties,
-				requiredFields: entityData.required,
-				definitionsIdToNameMap,
-			}).map(field => {
-				if ([container.containerData?.[0]?.isActivated, entityData.isActivated].includes(false)) {
-					// If the container or entity is not activated, set the field as not activated
-					return {
-						...field,
-						isActivated: false,
-					};
-				}
-				return field;
-			});
-
-			rootTypeNestedStatements.push(...entityFields);
+			return field;
 		});
+
+		rootTypeNestedStatements.push(...entityFields);
 	});
 
 	if (rootTypeNestedStatements.length === 0) {

--- a/forward_engineering/types/types.d.ts
+++ b/forward_engineering/types/types.d.ts
@@ -147,22 +147,21 @@ export type RootTypeNamesParameter = {
 	subscription: string;
 }
 
-export type ContainerData = {
-	containerData: object[]; // container properties by tab
-	jsonSchema: Record<string, string>; // JSON schemas of entities by entity ID
-	entityData: Record<string, object[]>; // entity properties by entity ID
-}
+export type EntityIdToJsonSchemaMap = Record<string, string>;
+export type EntityIdToPropertiesMap = Record<string, object[]>;
 
 // API parameters
-export type ModelScriptFEData = {
-	modelLevelData: object[]; // model level data
-	containers: ContainerData[]; // containers data
+export type ContainerLevelScriptFEData = {
+	modelData: object[]; // model level data
+	containerData: object[]; // container properties by tab
+	entityData: EntityIdToPropertiesMap; // entity properties by entity ID
+	jsonSchema: EntityIdToJsonSchemaMap; // JSON Schema by entity ID
 	externalDefinitions: string; // external definitions JSON Schema
 	modelDefinitions: string; // model definitions JSON Schema
 	targetScriptOptions: object; // target script options
 	options: {
 		additionalOptions: object[]; // additional options
-		isCalledFromFETab: boolean; // if the script is called from the forward engineering tab
+		origin: string; // "ui" if the script is called from the forward engineering tab
 	}
 };
 
@@ -170,7 +169,7 @@ export type Logger = {
 	log: (logType: string, logData: object, logMessage: string) => void;
 };
 
-export type GenerateModelScriptCallback = (error: Error | null, script?: string) => void;
+export type GenerateContainerLevelScriptCallback = (error: Error | null, script?: string) => void;
 
 export type ValidationResponseItem = {
 	type: string; // The type of the entity (e.g., 'error', 'success').

--- a/localization/en.json
+++ b/localization/en.json
@@ -10,6 +10,7 @@
 	"MAIN_MENU___APPEND_FIELD": "Append Field",
 	"MAIN_MENU___REVERSE_DB_COLLECTIONS": "GraphQL File...",
 	"MAIN_MENU___FORWARD_MODEL_COLLECTIONS": "GraphQL Schema...",
+	"MAIN_MENU___FORWARD_DB_BUCKETS": "GraphQL Schema...",
 	"TOOLBAR___ADD_BUCKET": "Add graph",
 	"TOOLBAR___ADD_COLLECTION": "Add operation",
 	"TOOLBAR___ADD_CHILD_COLLECTION": "Add Response",

--- a/properties_pane/container_level/containerLevelConfig.json
+++ b/properties_pane/container_level/containerLevelConfig.json
@@ -170,11 +170,38 @@ making sure that you maintain a proper JSON format.
 			},
 			{
 				"propertyName": "Directives",
-				"propertyKeyword": "directive",
-				"propertyTooltip": "Schema directives",
-				"propertyType": "details",
-				"template": "textarea",
-				"markdown": false
+				"propertyKeyword": "graphDirectives",
+				"propertyTooltip": "Graph directives",
+				"propertyType": "group",
+				"structure": [
+					{
+						"propertyName": "Directive format",
+						"propertyKeyword": "directiveFormat",
+						"propertyTooltip": "Select directive format",
+						"propertyType": "select",
+						"options": ["Raw"],
+						"defaultValue": "Raw",
+						"helpInfo": {
+							"type": "modal",
+							"title": "PROPERTIES_PANE___DIRECTIVES_INFO_MODAL_TITLE",
+							"content": "PROPERTIES_PANE___DIRECTIVES_INFO_MODAL_BODY",
+							"featureNameForHelp": "GraphQL directives",
+							"buttons": ["contactSupport", "ok"]
+						}
+					},
+					{
+						"propertyName": "Raw directive",
+						"propertyKeyword": "rawDirective",
+						"propertyTooltip": "Enter raw directive",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false,
+						"dependency": {
+							"key": "directiveFormat",
+							"value": "Raw"
+						}
+					}
+				]
 			},
 			{
 				"propertyName": "Comments",

--- a/test/forward_engineering/mappers/rootTypes.spec.js
+++ b/test/forward_engineering/mappers/rootTypes.spec.js
@@ -25,8 +25,8 @@ const {
 } = require('../../../forward_engineering/mappers/rootTypes');
 
 describe('getRootTypeNames', () => {
-	it('should return default root type names if no containers are provided', () => {
-		const result = getRootTypeNames({ containers: [] });
+	it('should return default root type names if no container properties are provided', () => {
+		const result = getRootTypeNames({ containerProperties: [] });
 		deepStrictEqual(result, {
 			query: 'Query',
 			mutation: 'Mutation',
@@ -34,21 +34,17 @@ describe('getRootTypeNames', () => {
 		});
 	});
 
-	it('should return trimmed root type names from containers', () => {
-		const containers = [
+	it('should return trimmed root type names from container properties', () => {
+		const containerProperties = [
 			{
-				containerData: [
-					{
-						schemaRootTypes: {
-							rootQuery: ' CustomQuery ',
-							rootMutation: 'CustomMutation',
-							rootSubscription: ' CustomSubscription ',
-						},
-					},
-				],
+				schemaRootTypes: {
+					rootQuery: ' CustomQuery ',
+					rootMutation: 'CustomMutation',
+					rootSubscription: ' CustomSubscription ',
+				},
 			},
 		];
-		const result = getRootTypeNames({ containers });
+		const result = getRootTypeNames({ containerProperties });
 		deepStrictEqual(result, {
 			query: 'CustomQuery',
 			mutation: 'CustomMutation',
@@ -56,21 +52,17 @@ describe('getRootTypeNames', () => {
 		});
 	});
 
-	it('should ignore empty root type names from containers', () => {
-		const containers = [
+	it('should ignore empty root type names from container properties', () => {
+		const containerProperties = [
 			{
-				containerData: [
-					{
-						schemaRootTypes: {
-							rootQuery: ' ',
-							rootMutation: '',
-							rootSubscription: ' CustomSubscription ',
-						},
-					},
-				],
+				schemaRootTypes: {
+					rootQuery: ' ',
+					rootMutation: '',
+					rootSubscription: ' CustomSubscription ',
+				},
 			},
 		];
-		const result = getRootTypeNames({ containers });
+		const result = getRootTypeNames({ containerProperties });
 		deepStrictEqual(result, {
 			query: 'Query',
 			mutation: 'Mutation',
@@ -80,7 +72,7 @@ describe('getRootTypeNames', () => {
 });
 
 describe('getRootSchemaStatement', () => {
-	it('should return null if all root types have default values', () => {
+	it('should return schema with all present root types', () => {
 		const rootTypeNames = {
 			query: 'Query',
 			mutation: 'Mutation',
@@ -91,8 +83,16 @@ describe('getRootSchemaStatement', () => {
 			{ statement: 'type Mutation' },
 			{ statement: 'type Subscription' },
 		];
-		const result = getRootSchemaStatement({ rootTypeNames, rootTypes });
-		strictEqual(result, null);
+		const result = getRootSchemaStatement({ rootTypeNames, rootTypes, containerProperties: [] });
+		deepStrictEqual(result, {
+			statement: 'schema',
+			description: '',
+			nestedStatements: [
+				{ statement: 'query: Query' },
+				{ statement: 'mutation: Mutation' },
+				{ statement: 'subscription: Subscription' },
+			],
+		});
 	});
 
 	it('should return schema statement with custom root types', () => {
@@ -106,10 +106,15 @@ describe('getRootSchemaStatement', () => {
 			{ statement: 'type Mutation' },
 			{ statement: 'type CustomSubscription' },
 		];
-		const result = getRootSchemaStatement({ rootTypeNames, rootTypes });
+		const result = getRootSchemaStatement({ rootTypeNames, rootTypes, containerProperties: [] });
 		deepStrictEqual(result, {
 			statement: 'schema',
-			nestedStatements: [{ statement: 'query: CustomQuery' }, { statement: 'subscription: CustomSubscription' }],
+			description: '',
+			nestedStatements: [
+				{ statement: 'query: CustomQuery' },
+				{ statement: 'mutation: Mutation' },
+				{ statement: 'subscription: CustomSubscription' },
+			],
 		});
 	});
 
@@ -119,22 +124,27 @@ describe('getRootSchemaStatement', () => {
 			mutation: 'Mutation',
 			subscription: 'CustomSubscription',
 		};
-		const rootTypes = [{ statement: 'type CustomQuery' }, { statement: 'type Mutation' }];
-		const result = getRootSchemaStatement({ rootTypeNames, rootTypes });
+		const rootTypes = [{ statement: 'type CustomQuery' }];
+		const result = getRootSchemaStatement({
+			rootTypeNames,
+			rootTypes,
+			containerProperties: [{ description: 'Graph description' }],
+		});
 		deepStrictEqual(result, {
 			statement: 'schema',
+			description: 'Graph description',
 			nestedStatements: [{ statement: 'query: CustomQuery' }],
 		});
 	});
 
-	it('should return null if no custom root types are present', () => {
+	it('should return null if no root types are present', () => {
 		const rootTypeNames = {
 			query: 'CustomQuery',
 			mutation: 'Mutation',
 			subscription: 'CustomSubscription',
 		};
-		const rootTypes = [{ statement: 'type Mutation' }];
-		const result = getRootSchemaStatement({ rootTypeNames, rootTypes });
+		const rootTypes = [];
+		const result = getRootSchemaStatement({ rootTypeNames, rootTypes, containerProperties: [] });
 		strictEqual(result, null);
 	});
 });
@@ -145,21 +155,17 @@ describe('getRootTypes', () => {
 	});
 
 	it('should return an array of root types', () => {
-		const containers = [
-			{
-				jsonSchema: {
-					entity1: JSON.stringify({
-						properties: {
-							field1: { type: 'String' },
-						},
-						required: ['field1'],
-					}),
+		const entitiesJsonSchema = {
+			entity1: JSON.stringify({
+				properties: {
+					field1: { type: 'String' },
 				},
-				entityData: {
-					entity1: [{ operationType: 'Query' }],
-				},
-			},
-		];
+				required: ['field1'],
+			}),
+		};
+		const entityProperties = {
+			entity1: [{ operationType: 'Query' }],
+		};
 		const rootTypeNames = {
 			query: 'CustomQuery',
 			mutation: 'Mutation',
@@ -168,7 +174,8 @@ describe('getRootTypes', () => {
 		getRootTypeFieldsMock.mock.mockImplementation(() => [{ statement: 'field1: String!' }]);
 
 		const result = getRootTypes({
-			containers,
+			entitiesJsonSchema,
+			entityProperties,
 			rootTypeNames,
 			definitionsIdToNameMap: {},
 		});
@@ -188,23 +195,20 @@ describe('getRootType', () => {
 	});
 
 	it('should return null if no entities match the root type', () => {
-		const containers = [
-			{
-				jsonSchema: {
-					entity1: JSON.stringify({
-						properties: {
-							field1: { type: 'String' },
-						},
-						required: ['field1'],
-					}),
+		const entitiesJsonSchema = {
+			entity1: JSON.stringify({
+				properties: {
+					field1: { type: 'String' },
 				},
-				entityData: {
-					entity1: [{ operationType: 'Mutation' }],
-				},
-			},
-		];
+				required: ['field1'],
+			}),
+		};
+		const entityProperties = {
+			entity1: [{ operationType: 'Mutation' }],
+		};
 		const result = getRootType({
-			containers,
+			entitiesJsonSchema,
+			entityProperties,
 			rootTypeName: 'CustomQuery',
 			definitionsIdToNameMap: {},
 			rootType: 'Query',
@@ -213,25 +217,22 @@ describe('getRootType', () => {
 	});
 
 	it('should return root type with nested statements', () => {
-		const containers = [
-			{
-				jsonSchema: {
-					entity1: JSON.stringify({
-						properties: {
-							field1: { type: 'String' },
-						},
-						required: ['field1'],
-					}),
+		const entitiesJsonSchema = {
+			entity1: JSON.stringify({
+				properties: {
+					field1: { type: 'String' },
 				},
-				entityData: {
-					entity1: [{ operationType: 'Query' }],
-				},
-			},
-		];
+				required: ['field1'],
+			}),
+		};
+		const entityProperties = {
+			entity1: [{ operationType: 'Query' }],
+		};
 		getRootTypeFieldsMock.mock.mockImplementation(() => [{ statement: 'field1: String!' }]);
 
 		const result = getRootType({
-			containers,
+			entitiesJsonSchema,
+			entityProperties,
 			rootTypeName: 'CustomQuery',
 			definitionsIdToNameMap: {},
 			rootType: 'Query',
@@ -242,27 +243,24 @@ describe('getRootType', () => {
 		});
 	});
 
-	it('should deactivate fields if container or entity is deactivated', () => {
-		const containers = [
-			{
-				containerData: [{ isActivated: false }],
-				jsonSchema: {
-					entity1: JSON.stringify({
-						properties: {
-							field1: { type: 'String', isActivated: true },
-						},
-						required: ['field1'],
-					}),
+	it('should deactivate fields if entity is deactivated', () => {
+		const entitiesJsonSchema = {
+			entity1: JSON.stringify({
+				properties: {
+					field1: { type: 'String', isActivated: true },
 				},
-				entityData: {
-					entity1: [{ operationType: 'Query' }],
-				},
-			},
-		];
+				required: ['field1'],
+				isActivated: false,
+			}),
+		};
+		const entityProperties = {
+			entity1: [{ operationType: 'Query' }],
+		};
 		getRootTypeFieldsMock.mock.mockImplementation(() => [{ statement: 'field1: String!', isActivated: true }]);
 
 		const result = getRootType({
-			containers,
+			entitiesJsonSchema,
+			entityProperties,
 			rootTypeName: 'CustomQuery',
 			definitionsIdToNameMap: {},
 			rootType: 'Query',
@@ -281,21 +279,18 @@ describe('getSchemaRootTypeStatements', () => {
 	});
 
 	it('should return formatted root type statements', () => {
-		const containers = [
-			{
-				jsonSchema: {
-					entity1: JSON.stringify({
-						properties: {
-							field1: { type: 'String' },
-						},
-						required: ['field1'],
-					}),
+		const containerProperties = [];
+		const entitiesJsonSchema = {
+			entity1: JSON.stringify({
+				properties: {
+					field1: { type: 'String' },
 				},
-				entityData: {
-					entity1: [{ operationType: 'Query' }],
-				},
-			},
-		];
+				required: ['field1'],
+			}),
+		};
+		const entityProperties = {
+			entity1: [{ operationType: 'Query' }],
+		};
 		const definitionsIdToNameMap = {};
 		getRootTypeFieldsMock.mock.mockImplementation(() => [{ statement: 'field1: String!' }]);
 		formatFEStatementMock.mock.mockImplementation(
@@ -305,8 +300,13 @@ describe('getSchemaRootTypeStatements', () => {
 				feStatement.nestedStatements.map(({ statement }) => statement).join('\n'),
 		);
 
-		const result = getSchemaRootTypeStatements({ containers, definitionsIdToNameMap });
+		const result = getSchemaRootTypeStatements({
+			containerProperties,
+			entitiesJsonSchema,
+			entityProperties,
+			definitionsIdToNameMap,
+		});
 
-		strictEqual(result, 'type Query\nfield1: String!');
+		strictEqual(result, 'schema\nquery: Query\n\ntype Query\nfield1: String!');
 	});
 });


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9837" title="HCK-9837" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9837</a>  FE: Container level + Add explicit schema definition with a declaration of the root types (Query, Mutation, and Subscription)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR makes the following changes:

1. **Switches the plugin FE to the container level instead of the model level.**
2. **Adds a `directives` property at the container level**, which is FE-d for the schema statement.
3. **Makes the schema statement more explicit**: 
   - The schema statement will now be present in the FE-d schema if at least one root type is present, regardless of whether the root type has a default or custom name.