### PR TITLE
HCK-9845: change order of directive locations

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1353,6 +1353,11 @@ making sure that you maintain a proper JSON format.
 					"propertyKeyword": "directiveLocations",
 					"structure": [
 						{
+							"propertyName": "Schema",
+							"propertyKeyword": "schema",
+							"propertyType": "checkbox"
+						},
+						{
 							"propertyName": "Query",
 							"propertyKeyword": "query",
 							"propertyType": "checkbox"
@@ -1368,43 +1373,8 @@ making sure that you maintain a proper JSON format.
 							"propertyType": "checkbox"
 						},
 						{
-							"propertyName": "Field",
-							"propertyKeyword": "field",
-							"propertyType": "checkbox"
-						},
-						{
-							"propertyName": "Schema",
-							"propertyKeyword": "schema",
-							"propertyType": "checkbox"
-						},
-						{
 							"propertyName": "Scalar",
 							"propertyKeyword": "scalar",
-							"propertyType": "checkbox"
-						},
-						{
-							"propertyName": "Object",
-							"propertyKeyword": "object",
-							"propertyType": "checkbox"
-						},
-						{
-							"propertyName": "Field definition",
-							"propertyKeyword": "fieldDefinition",
-							"propertyType": "checkbox"
-						},
-						{
-							"propertyName": "Argument definition",
-							"propertyKeyword": "argumentDefinition",
-							"propertyType": "checkbox"
-						},
-						{
-							"propertyName": "Interface",
-							"propertyKeyword": "interface",
-							"propertyType": "checkbox"
-						},
-						{
-							"propertyName": "Union",
-							"propertyKeyword": "union",
 							"propertyType": "checkbox"
 						},
 						{
@@ -1418,13 +1388,43 @@ making sure that you maintain a proper JSON format.
 							"propertyType": "checkbox"
 						},
 						{
+							"propertyName": "Object",
+							"propertyKeyword": "object",
+							"propertyType": "checkbox"
+						},
+						{
+							"propertyName": "Interface",
+							"propertyKeyword": "interface",
+							"propertyType": "checkbox"
+						},
+						{
+							"propertyName": "Union",
+							"propertyKeyword": "union",
+							"propertyType": "checkbox"
+						},
+						{
 							"propertyName": "Input object",
 							"propertyKeyword": "inputObject",
 							"propertyType": "checkbox"
 						},
 						{
+							"propertyName": "Field",
+							"propertyKeyword": "field",
+							"propertyType": "checkbox"
+						},
+						{
+							"propertyName": "Field definition",
+							"propertyKeyword": "fieldDefinition",
+							"propertyType": "checkbox"
+						},
+						{
 							"propertyName": "Input field definition",
 							"propertyKeyword": "inputFieldDefinition",
+							"propertyType": "checkbox"
+						},
+						{
+							"propertyName": "Argument definition",
+							"propertyKeyword": "argumentDefinition",
 							"propertyType": "checkbox"
 						}
 					]


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9845" title="HCK-9845" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9845</a>  Improve order of directive locations in the Directive PP (15)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

 Updated PP config for directives

...