### PR TITLE
HCK-9923: disable Polyglot actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,11 @@
             "disablePickFromFieldList": true,
             "hideDisabledAttributeTypes": true,
             "showReferenceDefinitionNameInsteadOfType": true,
-            "disableReplaceByAttributes": true
+            "disableReplaceByAttributes": true,
+            "polyglot": {
+                "disableDeriveFromPolyglotModel": true,
+                "disableConvertToPolyglotModel": true
+            }
         }
     },
     "description": "Hackolade plugin for GraphQL",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9923" title="HCK-9923" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9923</a>  Disable Polyglot Convert and Derive (as long as not ready)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

For now, the GraphQL target does not support the Polyglot-related actions (derive and convert), so they were disabled.