### PR TITLE
HCK-9960: show only disabled type directives for a union items

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -1639,8 +1639,17 @@ making sure that you maintain a proper JSON format.
 						}
 					],
 					"dependency": {
-						"key": "ref",
-						"exist": false
+						"type": "or",
+						"values": [
+							{
+								"key": "ref",
+								"exist": false
+							},
+							{
+								"key": "subschema",
+								"value": true
+							}
+						]
 					}
 				},
 				{
@@ -1742,8 +1751,17 @@ making sure that you maintain a proper JSON format.
 						}
 					],
 					"dependency": {
-						"key": "ref",
-						"exist": true
+						"type": "and",
+						"values": [
+							{
+								"key": "ref",
+								"exist": true
+							},
+							{
+								"key": "subschema",
+								"exist": false
+							}
+						]
 					}
 				},
 				"minProperties",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9960" title="HCK-9960" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-9960</a>  Union: Directive & implements of Object should not be in a "custom" prop tab
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

For union items that are choice subschemas referencing object types, it is not possible to use directives ([spec](https://spec.graphql.org/draft/#sec-Unions)).
- The editable directives input was hidden for these items.
- The object type definition directives will now be shown as disabled.