### PR TITLE
Enable insert/append context menu options for scalar and enum types

### DIFF
--- a/types/enum.json
+++ b/types/enum.json
@@ -11,10 +11,6 @@
 		"foreignField": [],
 		"ignore_z_value": true,
 		"subtype": "snippetChildrenOnly",
-		"hackoladeMeta": {
-			"disableAdd": true,
-			"disableAppend": true
-		},
 		"enum": []
 	},
 	"subtypes": {

--- a/types/scalar.json
+++ b/types/scalar.json
@@ -10,11 +10,7 @@
 		"foreignCollection": "",
 		"foreignField": [],
 		"ignore_z_value": true,
-		"subtype": "snippetChildrenOnly",
-		"hackoladeMeta": {
-			"disableAdd": true,
-			"disableAppend": true
-		}
+		"subtype": "snippetChildrenOnly"
 	},
 	"subtypes": {
 		"snippetChildrenOnly": {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10234" title="HCK-10234" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10234</a>  [GraphQL][Scalar/Enum types] 'Append/Insert Field' actions unexpectedly not available for those Types
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
