### PR TITLE
HCK-10334: add RE of interfaces

### DIFF
--- a/reverse_engineering/mappers/implementsInterfaces.js
+++ b/reverse_engineering/mappers/implementsInterfaces.js
@@ -1,0 +1,23 @@
+/**
+ * @import {NamedTypeNode} from "graphql"
+ * @import {REImplementsInterface} from "../../shared/types/types"
+ */
+
+/**
+ * Maps the implements interfaces
+ *
+ * @param {object} params
+ * @param {NamedTypeNode[]} [params.implementsInterfaces] - The implements interfaces
+ * @returns {REImplementsInterface[]} The mapped implements interfaces
+ */
+function mapImplementsInterfaces({ implementsInterfaces = [] }) {
+	return implementsInterfaces.map(interfaceData => {
+		return {
+			interface: interfaceData.name.value,
+		};
+	});
+}
+
+module.exports = {
+	mapImplementsInterfaces,
+};

--- a/reverse_engineering/mappers/typeDefinitions/interface.js
+++ b/reverse_engineering/mappers/typeDefinitions/interface.js
@@ -1,0 +1,59 @@
+/**
+ * @import {InterfaceTypeDefinitionNode} from "graphql"
+ * @import {DefinitionNameToTypeNameMap, FieldsOrder, REInterfaceDefinition, REPropertiesSchema} from "../../../shared/types/types"
+ */
+
+const { sortByName } = require('../../helpers/sortByName');
+const { mapDirectivesUsage } = require('../directiveUsage');
+const { mapField } = require('../field');
+const { mapImplementsInterfaces } = require('../implementsInterfaces');
+
+/**
+ * Maps interface type definitions
+ *
+ * @param {object} params
+ * @param {InterfaceTypeDefinitionNode[]} params.interfaces - The interface types
+ * @param {DefinitionNameToTypeNameMap} params.definitionCategoryByNameMap - The definition category by name map
+ * @param {FieldsOrder} params.fieldsOrder - The fields order
+ * @returns {REInterfaceDefinition[]} The mapped interface definitions
+ */
+function getInterfaceDefinitions({ interfaces = [], definitionCategoryByNameMap, fieldsOrder }) {
+	return interfaces.map(interfaceType => mapInterface({ interfaceType, definitionCategoryByNameMap, fieldsOrder }));
+}
+
+/**
+ * Maps a single interface type definition
+ *
+ * @param {object} params
+ * @param {InterfaceTypeDefinitionNode} params.interfaceType - The interface to map
+ * @param {DefinitionNameToTypeNameMap} params.definitionCategoryByNameMap - The definition category by name map
+ * @param {FieldsOrder} params.fieldsOrder - The fields order
+ * @returns {REInterfaceDefinition} The mapped interface type definition
+ */
+function mapInterface({ interfaceType, definitionCategoryByNameMap, fieldsOrder }) {
+	const properties = interfaceType.fields
+		? interfaceType.fields.map(field => mapField({ field, definitionCategoryByNameMap }))
+		: [];
+	const required = properties.filter(property => property.required).map(property => property.name);
+	const convertedProperties = sortByName({ items: properties, fieldsOrder }).reduce(
+		(acc, property) => {
+			acc[property.name] = property;
+			return acc;
+		},
+		/** @type {REPropertiesSchema} */ {},
+	);
+
+	return {
+		type: 'interface',
+		name: interfaceType.name.value,
+		properties: convertedProperties,
+		required,
+		description: interfaceType.description?.value || '',
+		typeDirectives: mapDirectivesUsage({ directives: [...(interfaceType.directives || [])] }),
+		implementsInterfaces: mapImplementsInterfaces({ implementsInterfaces: [...(interfaceType.interfaces || [])] }),
+	};
+}
+
+module.exports = {
+	getInterfaceDefinitions,
+};

--- a/reverse_engineering/mappers/typeDefinitions/objectType.js
+++ b/reverse_engineering/mappers/typeDefinitions/objectType.js
@@ -6,6 +6,7 @@
 const { sortByName } = require('../../helpers/sortByName');
 const { mapDirectivesUsage } = require('../directiveUsage');
 const { mapField } = require('../field');
+const { mapImplementsInterfaces } = require('../implementsInterfaces');
 
 /**
  * Maps object type definitions
@@ -49,7 +50,7 @@ function mapObjectType({ objectType, definitionCategoryByNameMap, fieldsOrder })
 		required,
 		description: objectType.description?.value || '',
 		typeDirectives: mapDirectivesUsage({ directives: [...(objectType.directives || [])] }),
-		// TODO: add interfaces
+		implementsInterfaces: mapImplementsInterfaces({ implementsInterfaces: [...(objectType.interfaces || [])] }),
 	};
 }
 

--- a/reverse_engineering/mappers/typeDefinitions/typeDefinitions.js
+++ b/reverse_engineering/mappers/typeDefinitions/typeDefinitions.js
@@ -12,7 +12,9 @@
  * 		EnumStructureType,
  * 		ObjectStructureType,
  * 		ScalarStructureType,
- * REObjectTypeDefinition} from "../../../shared/types/types"
+ * REObjectTypeDefinition,
+ * InterfaceStructureType,
+ * REInterfaceDefinition} from "../../../shared/types/types"
  */
 
 const { astNodeKind } = require('../../constants/graphqlAST');
@@ -23,6 +25,7 @@ const { getCustomScalarTypeDefinitions } = require('./customScalar');
 const { getDirectiveTypeDefinitions } = require('./directive');
 const { getObjectTypeDefinitions } = require('./objectType');
 const { getEnumTypeDefinitions } = require('./enum');
+const { getInterfaceDefinitions } = require('./interface');
 
 /**
  * Gets the type definitions structure
@@ -56,7 +59,20 @@ function getTypeDefinitions({ typeDefinitions, fieldsOrder, rootTypeNames }) {
 		fieldsOrder,
 	});
 
-	const definitions = getTypeDefinitionsStructure({ fieldsOrder, directives, customScalars, enums, objectTypes });
+	const interfaces = getInterfaceDefinitions({
+		interfaces: findNodesByKind({ nodes: typeDefinitions, kind: astNodeKind.INTERFACE_TYPE_DEFINITION }),
+		definitionCategoryByNameMap,
+		fieldsOrder,
+	});
+
+	const definitions = getTypeDefinitionsStructure({
+		fieldsOrder,
+		directives,
+		customScalars,
+		enums,
+		objectTypes,
+		interfaces,
+	});
 
 	return definitions;
 }
@@ -70,9 +86,10 @@ function getTypeDefinitions({ typeDefinitions, fieldsOrder, rootTypeNames }) {
  * @param {RECustomScalarDefinition[]} params.customScalars - The custom scalar definitions
  * @param {REEnumDefinition[]} params.enums - The enum definitions
  * @param {REObjectTypeDefinition[]} params.objectTypes - The object type definitions
+ * @param {REInterfaceDefinition[]} params.interfaces - The interface definitions
  * @returns {REModelDefinitionsSchema} The type definitions structure
  */
-function getTypeDefinitionsStructure({ fieldsOrder, directives, customScalars, enums, objectTypes }) {
+function getTypeDefinitionsStructure({ fieldsOrder, directives, customScalars, enums, objectTypes, interfaces }) {
 	const definitions = {
 		['Directives']: /** @type {DirectiveStructureType} */ (
 			getDefinitionCategoryStructure({
@@ -100,6 +117,13 @@ function getTypeDefinitionsStructure({ fieldsOrder, directives, customScalars, e
 				fieldsOrder,
 				subtype: 'enum',
 				properties: enums,
+			})
+		),
+		['Interfaces']: /** @type {InterfaceStructureType} */ (
+			getDefinitionCategoryStructure({
+				fieldsOrder,
+				subtype: 'interface',
+				properties: interfaces,
 			})
 		),
 	};

--- a/shared/types/re.d.ts
+++ b/shared/types/re.d.ts
@@ -124,8 +124,14 @@ export type REDirectiveDefinitionsSchema = Record<string, REDirectiveDefinition>
 export type RECustomScalarDefinitionsSchema = Record<string, RECustomScalarDefinition>;
 export type REObjectDefinitionsSchema = Record<string, REObjectTypeDefinition>;
 export type REEnumDefinitionsSchema = Record<string, REEnumDefinition>;
+export type REInterfaceDefinitionsSchema = Record<string, REInterfaceDefinition>;
 
-export type REDefinition = RECustomScalarDefinition | REDirectiveDefinition | REEnumDefinition | REObjectTypeDefinition;
+export type REDefinition =
+	| RECustomScalarDefinition
+	| REDirectiveDefinition
+	| REEnumDefinition
+	| REObjectTypeDefinition
+	| REInterfaceDefinition;
 
 export type REModelDefinitionsSchema = {
 	definitions: {
@@ -133,6 +139,7 @@ export type REModelDefinitionsSchema = {
 		Scalars: ScalarStructureType;
 		Objects: ObjectStructureType;
 		Enums: EnumStructureType;
+		Interfaces: InterfaceStructureType;
 	};
 };
 
@@ -140,7 +147,8 @@ export type DefinitionREStructure =
 	| DirectiveStructureType
 	| ScalarStructureType
 	| EnumStructureType
-	| ObjectStructureType;
+	| ObjectStructureType
+	| InterfaceStructureType;
 
 type StructureType<T> = {
 	type: 'type';
@@ -158,6 +166,10 @@ export type ScalarStructureType = StructureType<RECustomScalarDefinitionsSchema>
 
 export type EnumStructureType = StructureType<REEnumDefinitionsSchema> & {
 	subtype: 'enum';
+};
+
+export type InterfaceStructureType = StructureType<REEnumDefinitionsSchema> & {
+	subtype: 'interface';
 };
 
 export type RECustomScalarDefinition = CustomScalarDefinition<StructuredDirective> & {
@@ -185,6 +197,11 @@ type REObjectLikeDefinition = ObjectLikeDefinition<REImplementsInterface, Struct
 
 export type REObjectTypeDefinition = REObjectLikeDefinition & {
 	type: 'object';
+	name: string;
+};
+
+export type REInterfaceDefinition = REObjectLikeDefinition & {
+	type: 'interface';
 	name: string;
 };
 

--- a/test/reverse_engineering/mappers/typeDefinitions/interface.spec.js
+++ b/test/reverse_engineering/mappers/typeDefinitions/interface.spec.js
@@ -19,7 +19,6 @@ mock.module('../../../../reverse_engineering/mappers/directiveUsage', {
 const mapFieldMock = mock.fn(({ field }) => ({
 	name: field.name.value,
 	required: field.type.kind === 'NON_NULL_TYPE',
-	// Add other properties that mapField would return
 }));
 mock.module('../../../../reverse_engineering/mappers/field', {
 	namedExports: {
@@ -34,9 +33,9 @@ mock.module('../../../../reverse_engineering/mappers/implementsInterfaces', {
 	},
 });
 
-const { getObjectTypeDefinitions } = require('../../../../reverse_engineering/mappers/typeDefinitions/objectType');
+const { getInterfaceDefinitions } = require('../../../../reverse_engineering/mappers/typeDefinitions/interface');
 
-describe('getObjectTypeDefinitions', () => {
+describe('getInterfaceDefinitions', () => {
 	afterEach(() => {
 		sortByNameMock.mock.resetCalls();
 		mapDirectivesUsageMock.mock.resetCalls();
@@ -44,18 +43,18 @@ describe('getObjectTypeDefinitions', () => {
 		mapImplementsInterfacesMock.mock.resetCalls();
 	});
 
-	it('should return an empty array when no object types are provided', () => {
-		const result = getObjectTypeDefinitions({
-			objectTypes: [],
+	it('should return an empty array when no interface types are provided', () => {
+		const result = getInterfaceDefinitions({
+			interfaces: [],
 			definitionCategoryByNameMap: {},
 			fieldsOrder: {},
 		});
 		assert.deepStrictEqual(result, []);
 	});
 
-	it('should correctly map a simple object type with no fields', () => {
-		const mockObjectType = {
-			name: { value: 'EmptyType' },
+	it('should correctly map a simple interface with no fields', () => {
+		const mockInterface = {
+			name: { value: 'EmptyInterface' },
 			fields: [],
 			directives: [],
 			interfaces: [],
@@ -63,8 +62,8 @@ describe('getObjectTypeDefinitions', () => {
 
 		const expected = [
 			{
-				type: 'object',
-				name: 'EmptyType',
+				type: 'interface',
+				name: 'EmptyInterface',
 				properties: {},
 				required: [],
 				description: '',
@@ -73,8 +72,8 @@ describe('getObjectTypeDefinitions', () => {
 			},
 		];
 
-		const result = getObjectTypeDefinitions({
-			objectTypes: [mockObjectType],
+		const result = getInterfaceDefinitions({
+			interfaces: [mockInterface],
 			definitionCategoryByNameMap: {},
 			fieldsOrder: {},
 		});
@@ -84,15 +83,12 @@ describe('getObjectTypeDefinitions', () => {
 		assert.strictEqual(sortByNameMock.mock.calls.length, 1);
 		assert.strictEqual(mapFieldMock.mock.calls.length, 0);
 		assert.strictEqual(mapImplementsInterfacesMock.mock.calls.length, 1);
-		assert.deepStrictEqual(mapImplementsInterfacesMock.mock.calls[0].arguments[0], {
-			implementsInterfaces: mockObjectType.interfaces,
-		});
 	});
 
-	it('should correctly map an object type with fields', () => {
-		const mockObjectType = {
-			name: { value: 'User' },
-			description: { value: 'A user object' },
+	it('should correctly map an interface with fields', () => {
+		const mockInterface = {
+			name: { value: 'Node' },
+			description: { value: 'An interface for objects with an ID' },
 			fields: [
 				{
 					name: { value: 'id' },
@@ -106,32 +102,27 @@ describe('getObjectTypeDefinitions', () => {
 				},
 			],
 			directives: [],
+			interfaces: [],
 		};
-
-		// Setup the mapField mock to return expected values
-		mapFieldMock.mock.mockImplementation(({ field }) => ({
-			name: field.name.value,
-			required: field.type.kind === 'NON_NULL_TYPE',
-		}));
 
 		// Expected result with the properties based on the mocked mapField responses
 		const expected = [
 			{
-				type: 'object',
-				name: 'User',
+				type: 'interface',
+				name: 'Node',
 				properties: {
 					id: { name: 'id', required: true },
 					name: { name: 'name', required: false },
 				},
 				required: ['id'],
-				description: 'A user object',
+				description: 'An interface for objects with an ID',
 				typeDirectives: [],
 				implementsInterfaces: [],
 			},
 		];
 
-		const result = getObjectTypeDefinitions({
-			objectTypes: [mockObjectType],
+		const result = getInterfaceDefinitions({
+			interfaces: [mockInterface],
 			definitionCategoryByNameMap: {},
 			fieldsOrder: {},
 		});
@@ -140,19 +131,20 @@ describe('getObjectTypeDefinitions', () => {
 		assert.strictEqual(mapDirectivesUsageMock.mock.calls.length, 1);
 		assert.strictEqual(sortByNameMock.mock.calls.length, 1);
 		assert.strictEqual(mapFieldMock.mock.calls.length, 2);
+		assert.strictEqual(mapImplementsInterfacesMock.mock.calls.length, 1);
 	});
 
-	it('should correctly map an object type with directives', () => {
-		const mockDirectiveResult = [{ directiveName: '@auth', rawArgumentValues: 'requires: "ADMIN"' }];
+	it('should correctly map an interface with directives', () => {
+		const mockDirectiveResult = [{ directiveName: '@deprecated', rawArgumentValues: 'reason: "Use Node instead"' }];
 		mapDirectivesUsageMock.mock.mockImplementationOnce(() => mockDirectiveResult);
 
-		const mockObjectType = {
-			name: { value: 'AdminType' },
+		const mockInterface = {
+			name: { value: 'OldInterface' },
 			fields: [],
 			directives: [
 				{
-					name: { value: 'auth' },
-					arguments: [{ name: { value: 'requires' }, value: { value: 'ADMIN' } }],
+					name: { value: 'deprecated' },
+					arguments: [{ name: { value: 'reason' }, value: { value: 'Use Node instead' } }],
 				},
 			],
 			interfaces: [],
@@ -160,8 +152,8 @@ describe('getObjectTypeDefinitions', () => {
 
 		const expected = [
 			{
-				type: 'object',
-				name: 'AdminType',
+				type: 'interface',
+				name: 'OldInterface',
 				properties: {},
 				required: [],
 				description: '',
@@ -170,8 +162,8 @@ describe('getObjectTypeDefinitions', () => {
 			},
 		];
 
-		const result = getObjectTypeDefinitions({
-			objectTypes: [mockObjectType],
+		const result = getInterfaceDefinitions({
+			interfaces: [mockInterface],
 			definitionCategoryByNameMap: {},
 			fieldsOrder: {},
 		});
@@ -179,36 +171,36 @@ describe('getObjectTypeDefinitions', () => {
 		assert.deepStrictEqual(result, expected);
 		assert.strictEqual(mapDirectivesUsageMock.mock.calls.length, 1);
 		assert.deepStrictEqual(mapDirectivesUsageMock.mock.calls[0].arguments[0], {
-			directives: mockObjectType.directives,
+			directives: mockInterface.directives,
 		});
+		assert.strictEqual(mapImplementsInterfacesMock.mock.calls.length, 1);
 	});
 
-	// Add new test for implements interfaces
-	it('should correctly map an object type that implements interfaces', () => {
-		const mockObjectType = {
-			name: { value: 'User' },
+	it('should correctly handle inherited interfaces', () => {
+		const mockInterface = {
+			name: { value: 'ExtendedNode' },
 			fields: [],
 			directives: [],
 			interfaces: [{ name: { value: 'Node' } }, { name: { value: 'Entity' } }],
 		};
 
-		const mockInterfacesResult = [{ interface: 'Node' }, { interface: 'Entity' }];
-		mapImplementsInterfacesMock.mock.mockImplementationOnce(() => mockInterfacesResult);
+		const mockImplementsResult = [{ interface: 'Node' }, { interface: 'Entity' }];
+		mapImplementsInterfacesMock.mock.mockImplementationOnce(() => mockImplementsResult);
 
 		const expected = [
 			{
-				type: 'object',
-				name: 'User',
+				type: 'interface',
+				name: 'ExtendedNode',
 				properties: {},
 				required: [],
 				description: '',
 				typeDirectives: [],
-				implementsInterfaces: mockInterfacesResult,
+				implementsInterfaces: mockImplementsResult,
 			},
 		];
 
-		const result = getObjectTypeDefinitions({
-			objectTypes: [mockObjectType],
+		const result = getInterfaceDefinitions({
+			interfaces: [mockInterface],
 			definitionCategoryByNameMap: {},
 			fieldsOrder: {},
 		});
@@ -216,13 +208,13 @@ describe('getObjectTypeDefinitions', () => {
 		assert.deepStrictEqual(result, expected);
 		assert.strictEqual(mapImplementsInterfacesMock.mock.calls.length, 1);
 		assert.deepStrictEqual(mapImplementsInterfacesMock.mock.calls[0].arguments[0], {
-			implementsInterfaces: mockObjectType.interfaces,
+			implementsInterfaces: mockInterface.interfaces,
 		});
 	});
 
 	it('should correctly handle fields order', () => {
-		const mockObjectType = {
-			name: { value: 'OrderedType' },
+		const mockInterface = {
+			name: { value: 'OrderedInterface' },
 			fields: [
 				{ name: { value: 'fieldB' }, type: { kind: 'NAMED_TYPE' }, directives: [] },
 				{ name: { value: 'fieldA' }, type: { kind: 'NAMED_TYPE' }, directives: [] },
@@ -253,6 +245,7 @@ describe('getObjectTypeDefinitions', () => {
 			// Reset mocks before each test case
 			sortByNameMock.mock.resetCalls();
 			mapFieldMock.mock.resetCalls();
+			mapImplementsInterfacesMock.mock.resetCalls();
 
 			// Mock sortByName to simulate behavior based on fieldsOrder value
 			if (testCase.fieldsOrder === 'alphabetical') {
@@ -265,8 +258,8 @@ describe('getObjectTypeDefinitions', () => {
 				sortByNameMock.mock.mockImplementationOnce(({ items }) => items);
 			}
 
-			const result = getObjectTypeDefinitions({
-				objectTypes: [mockObjectType],
+			const result = getInterfaceDefinitions({
+				interfaces: [mockInterface],
 				definitionCategoryByNameMap: {},
 				fieldsOrder: testCase.fieldsOrder,
 			});
@@ -277,7 +270,7 @@ describe('getObjectTypeDefinitions', () => {
 
 			// Verify the result structure
 			assert.strictEqual(result.length, 1);
-			assert.strictEqual(result[0].name, 'OrderedType');
+			assert.strictEqual(result[0].name, 'OrderedInterface');
 
 			const propertyNames = Object.keys(result[0].properties);
 
@@ -290,37 +283,38 @@ describe('getObjectTypeDefinitions', () => {
 		}
 	});
 
-	it('should correctly map multiple object types', () => {
-		const mockObjectTypes = [
+	it('should correctly map multiple interface types', () => {
+		const mockInterfaces = [
 			{
-				name: { value: 'Type1' },
+				name: { value: 'Interface1' },
 				fields: [],
 				directives: [],
 				interfaces: [],
 			},
 			{
-				name: { value: 'Type2' },
+				name: { value: 'Interface2' },
 				fields: [],
 				directives: [],
 				interfaces: [],
 			},
 		];
 
-		const result = getObjectTypeDefinitions({
-			objectTypes: mockObjectTypes,
+		const result = getInterfaceDefinitions({
+			interfaces: mockInterfaces,
 			definitionCategoryByNameMap: {},
 			fieldsOrder: {},
 		});
 
 		assert.strictEqual(result.length, 2);
-		assert.strictEqual(result[0].name, 'Type1');
-		assert.strictEqual(result[1].name, 'Type2');
+		assert.strictEqual(result[0].name, 'Interface1');
+		assert.strictEqual(result[1].name, 'Interface2');
 		assert.strictEqual(mapDirectivesUsageMock.mock.calls.length, 2);
+		assert.strictEqual(mapImplementsInterfacesMock.mock.calls.length, 2);
 	});
 
 	it('should handle undefined fields', () => {
-		const mockObjectType = {
-			name: { value: 'TypeWithoutFields' },
+		const mockInterface = {
+			name: { value: 'InterfaceWithoutFields' },
 			// fields is undefined
 			directives: [],
 			interfaces: [],
@@ -328,8 +322,8 @@ describe('getObjectTypeDefinitions', () => {
 
 		const expected = [
 			{
-				type: 'object',
-				name: 'TypeWithoutFields',
+				type: 'interface',
+				name: 'InterfaceWithoutFields',
 				properties: {},
 				required: [],
 				description: '',
@@ -338,8 +332,8 @@ describe('getObjectTypeDefinitions', () => {
 			},
 		];
 
-		const result = getObjectTypeDefinitions({
-			objectTypes: [mockObjectType],
+		const result = getInterfaceDefinitions({
+			interfaces: [mockInterface],
 			definitionCategoryByNameMap: {},
 			fieldsOrder: {},
 		});
@@ -355,8 +349,8 @@ describe('getObjectTypeDefinitions', () => {
 	});
 
 	it('should handle undefined directives', () => {
-		const mockObjectType = {
-			name: { value: 'TypeWithoutDirectives' },
+		const mockInterface = {
+			name: { value: 'InterfaceWithoutDirectives' },
 			fields: [],
 			// directives is undefined
 			interfaces: [],
@@ -364,8 +358,8 @@ describe('getObjectTypeDefinitions', () => {
 
 		const expected = [
 			{
-				type: 'object',
-				name: 'TypeWithoutDirectives',
+				type: 'interface',
+				name: 'InterfaceWithoutDirectives',
 				properties: {},
 				required: [],
 				description: '',
@@ -374,8 +368,8 @@ describe('getObjectTypeDefinitions', () => {
 			},
 		];
 
-		const result = getObjectTypeDefinitions({
-			objectTypes: [mockObjectType],
+		const result = getInterfaceDefinitions({
+			interfaces: [mockInterface],
 			definitionCategoryByNameMap: {},
 			fieldsOrder: {},
 		});
@@ -387,10 +381,9 @@ describe('getObjectTypeDefinitions', () => {
 		assert.deepStrictEqual(mapDirectivesUsageMock.mock.calls[0].arguments[0].directives, []);
 	});
 
-	// Add test for undefined interfaces
 	it('should handle undefined interfaces', () => {
-		const mockObjectType = {
-			name: { value: 'TypeWithoutInterfaces' },
+		const mockInterface = {
+			name: { value: 'InterfaceWithoutImplements' },
 			fields: [],
 			directives: [],
 			// interfaces is undefined
@@ -398,8 +391,8 @@ describe('getObjectTypeDefinitions', () => {
 
 		const expected = [
 			{
-				type: 'object',
-				name: 'TypeWithoutInterfaces',
+				type: 'interface',
+				name: 'InterfaceWithoutImplements',
 				properties: {},
 				required: [],
 				description: '',
@@ -408,8 +401,8 @@ describe('getObjectTypeDefinitions', () => {
 			},
 		];
 
-		const result = getObjectTypeDefinitions({
-			objectTypes: [mockObjectType],
+		const result = getInterfaceDefinitions({
+			interfaces: [mockInterface],
 			definitionCategoryByNameMap: {},
 			fieldsOrder: {},
 		});


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10334" title="HCK-10334" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10334</a>  Add interface type definitions RE
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR adds RE of interface type definitions and "Implements" interfaces for object and interface types.