### PR TITLE
Fine-tune FE script formatting

### DIFF
--- a/forward_engineering/helpers/descriptionsHelper.js
+++ b/forward_engineering/helpers/descriptionsHelper.js
@@ -12,13 +12,15 @@ function getStatementDescription({ description }) {
 	}
 
 	const trimmedDescription = description.trim();
-	const escapedDescription = trimmedDescription.replace(/"/g, '\\"');
-	const isMultiLine = escapedDescription.includes('\n');
+	const isMultiLine = trimmedDescription.includes('\n');
 
-	// Format the description based on whether it is multi-line or single-line
-	const formattedDescription = isMultiLine ? `"""\n${escapedDescription}\n"""` : `"${escapedDescription}"`;
+	if (!isMultiLine) {
+		// Escape double quotes for single-line descriptions
+		const escapedDescription = trimmedDescription.replace(/"/g, '\\"');
+		return `"${escapedDescription}"`;
+	}
 
-	return formattedDescription;
+	return `"""\n${trimmedDescription}\n"""`;
 }
 
 module.exports = {

--- a/forward_engineering/mappers/arguments.js
+++ b/forward_engineering/mappers/arguments.js
@@ -70,9 +70,10 @@ const mapArgument = ({ graphqlArgument, idToNameMap = {} }) => {
  * @param {Object} args - arguments object.
  * @param {Argument[]} args.graphqlArguments - The arguments to map.
  * @param {IdToNameMap} [args.idToNameMap] - The ID to name map of all available types in model.
- * @returns {Object} returns an object containing the arguments as a formatted string and a warning comment if any.
- * @returns {string} returns.argumentsStatement - The formatted arguments string.
- * @returns {string} returns.argumentsWarningComment - The warning comment if any argument is missing a type.
+ * @returns {{
+ *   argumentsStatement: string,
+ *   argumentsWarningComment: string
+ * }} An object containing the arguments as a formatted string and a warning comment if any argument is missing the type.
  */
 const getArguments = ({ graphqlArguments, idToNameMap = {} }) => {
 	if (!Array.isArray(graphqlArguments) || graphqlArguments.length === 0) {

--- a/forward_engineering/mappers/directives.js
+++ b/forward_engineering/mappers/directives.js
@@ -53,7 +53,7 @@ function mapDirective({ name, directive, definitionsIdToNameMap }) {
 	});
 
 	return {
-		statement: `directive ${directiveName}${argumentsStatement} on ${directiveLocations}`,
+		statement: `directive ${directiveName}${argumentsStatement.trimStart()} on ${directiveLocations}`,
 		description: directive.description || '',
 		isActivated: directive.isActivated,
 		comment: argumentsWarningComment,

--- a/forward_engineering/mappers/fields.js
+++ b/forward_engineering/mappers/fields.js
@@ -53,7 +53,7 @@ function mapField({ name, fieldData, required, definitionsIdToNameMap, addArgume
 	const { argumentsStatement, argumentsWarningComment } = addArguments
 		? getArguments({ graphqlArguments: fieldData.arguments, idToNameMap: definitionsIdToNameMap })
 		: { argumentsStatement: '', argumentsWarningComment: '' };
-	const fieldNameStatement = joinInlineStatements({ statements: [name, argumentsStatement] });
+	const fieldNameStatement = joinInlineStatements({ statements: [name, argumentsStatement], separator: '' });
 	const fieldTypeStatement = `${fieldNameStatement}: ${getFieldType({ field: fieldData, required })}`;
 	const fieldDefaultValue = addDefaultValue ? getFieldDefaultValueStatement({ field: fieldData }) : '';
 	const directivesStatement = getDirectivesUsageStatement({

--- a/test/forward_engineering/expectedSchema.graphql
+++ b/test/forward_engineering/expectedSchema.graphql
@@ -8,7 +8,7 @@ schema {
 }
 
 "An active custom directive example"
-directive @activeDirective (
+directive @activeDirective(
   "An example argument"
   arg1: String! = "TEST"
 ) on ARGUMENT_DEFINITION | ENUM | ENUM_VALUE | FIELD | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | INPUT_OBJECT | INTERFACE | MUTATION | OBJECT | QUERY | SCALAR | SCHEMA | SUBSCRIPTION | UNION
@@ -16,14 +16,14 @@ directive @activeDirective (
 # directive @deactivetedDirective on UNKNOWN_LOCATION # Please specify the directive locations
 
 type TestQuery {
-  student (
+  student(
     "Specify ID of user to fetch"
     id: ID! = "1" @activeDirective(arg1: "TEST111")
   ): Student
 }
 
 type TestMutation {
-  student (id: ID! = "1"): Student @activeDirective(arg1: "TEST222")
+  student(id: ID! = "1"): Student @activeDirective(arg1: "TEST222")
 }
 
 type TestSubscription {


### PR DESCRIPTION
## Content

This PR finetunes GraphQL forward engineering script formatting to improve consistency and readability:

- Quotes are now escaped only for single-line descriptions (wrapped in single double quotes) and not for multi-line descriptions (wrapped in triple double quotes)
- Removed space between field/directive names and their arguments to be consistent with common GraphQL formatting style