### PR TITLE
HCK-10771: add support of all available directive locations for FE and RE

### DIFF
--- a/forward_engineering/constants/feScriptConstants.js
+++ b/forward_engineering/constants/feScriptConstants.js
@@ -1,23 +1,5 @@
 const GRAPHQL_SCHEMA_SCRIPT_INDENT = '  ';
 
-const DIRECTIVE_LOCATIONS = {
-	argumentDefinition: 'ARGUMENT_DEFINITION',
-	enum: 'ENUM',
-	enumValue: 'ENUM_VALUE',
-	field: 'FIELD',
-	fieldDefinition: 'FIELD_DEFINITION',
-	inputFieldDefinition: 'INPUT_FIELD_DEFINITION',
-	inputObject: 'INPUT_OBJECT',
-	interface: 'INTERFACE',
-	mutation: 'MUTATION',
-	object: 'OBJECT',
-	query: 'QUERY',
-	scalar: 'SCALAR',
-	schema: 'SCHEMA',
-	subscription: 'SUBSCRIPTION',
-	union: 'UNION',
-};
-
 const QUERY_ROOT_TYPE = 'Query';
 const MUTATION_ROOT_TYPE = 'Mutation';
 const SUBSCRIPTION_ROOT_TYPE = 'Subscription';
@@ -26,7 +8,6 @@ const MISSED_ARG_TYPE_COMMENT = 'MISSING ARGUMENT TYPE';
 
 module.exports = {
 	GRAPHQL_SCHEMA_SCRIPT_INDENT,
-	DIRECTIVE_LOCATIONS,
 	QUERY_ROOT_TYPE,
 	MUTATION_ROOT_TYPE,
 	SUBSCRIPTION_ROOT_TYPE,

--- a/forward_engineering/mappers/directives.js
+++ b/forward_engineering/mappers/directives.js
@@ -2,7 +2,7 @@
  * @import {FEDirectiveDefinitionsSchema, FEDirectiveDefinition, FEStatement, DirectiveLocations, IdToNameMap} from "../../shared/types/types"
  */
 
-const { DIRECTIVE_LOCATIONS } = require('../constants/feScriptConstants');
+const { DIRECTIVE_LOCATIONS } = require('../../shared/constants/directive');
 const { getArguments } = require('./arguments');
 
 const UNKNOWN_LOCATION = 'UNKNOWN_LOCATION';

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -2617,6 +2617,26 @@ making sure that you maintain a proper JSON format.
 							"propertyName": "Argument definition",
 							"propertyKeyword": "argumentDefinition",
 							"propertyType": "checkbox"
+						},
+						{
+							"propertyName": "Fragment definition",
+							"propertyKeyword": "fragmentDefinition",
+							"propertyType": "checkbox"
+						},
+						{
+							"propertyName": "Fragment spread",
+							"propertyKeyword": "fragmentSpread",
+							"propertyType": "checkbox"
+						},
+						{
+							"propertyName": "Inline fragment",
+							"propertyKeyword": "inlineFragment",
+							"propertyType": "checkbox"
+						},
+						{
+							"propertyName": "Variable definition",
+							"propertyKeyword": "variableDefinition",
+							"propertyType": "checkbox"
 						}
 					]
 				},

--- a/reverse_engineering/mappers/typeDefinitions/directive.js
+++ b/reverse_engineering/mappers/typeDefinitions/directive.js
@@ -5,24 +5,10 @@
 
 const { getArguments } = require('../arguments');
 const { getDirectiveName } = require('../directiveName');
+const { DIRECTIVE_LOCATIONS } = require('../../../shared/constants/directive');
 
-const locationMap = {
-	'SCHEMA': 'schema',
-	'QUERY': 'query',
-	'MUTATION': 'mutation',
-	'SUBSCRIPTION': 'subscription',
-	'SCALAR': 'scalar',
-	'ENUM': 'enum',
-	'ENUM_VALUE': 'enumValue',
-	'OBJECT': 'object',
-	'INTERFACE': 'interface',
-	'UNION': 'union',
-	'INPUT_OBJECT': 'inputObject',
-	'FIELD': 'field',
-	'FIELD_DEFINITION': 'fieldDefinition',
-	'INPUT_FIELD_DEFINITION': 'inputFieldDefinition',
-	'ARGUMENT_DEFINITION': 'argumentDefinition',
-};
+// Inverted the DIRECTIVE_LOCATIONS object to map location names from GraphQL SDL to location names in Hackolade properties
+const locationMap = Object.fromEntries(Object.entries(DIRECTIVE_LOCATIONS).map(([key, value]) => [value, key]));
 
 /**
  * Maps the directive type definitions

--- a/shared/constants/directive.js
+++ b/shared/constants/directive.js
@@ -1,0 +1,25 @@
+const DIRECTIVE_LOCATIONS = {
+	argumentDefinition: 'ARGUMENT_DEFINITION',
+	enum: 'ENUM',
+	enumValue: 'ENUM_VALUE',
+	field: 'FIELD',
+	fieldDefinition: 'FIELD_DEFINITION',
+	inputFieldDefinition: 'INPUT_FIELD_DEFINITION',
+	inputObject: 'INPUT_OBJECT',
+	interface: 'INTERFACE',
+	mutation: 'MUTATION',
+	object: 'OBJECT',
+	query: 'QUERY',
+	scalar: 'SCALAR',
+	schema: 'SCHEMA',
+	subscription: 'SUBSCRIPTION',
+	union: 'UNION',
+	fragmentDefinition: 'FRAGMENT_DEFINITION',
+	fragmentSpread: 'FRAGMENT_SPREAD',
+	inlineFragment: 'INLINE_FRAGMENT',
+	variableDefinition: 'VARIABLE_DEFINITION',
+};
+
+module.exports = {
+	DIRECTIVE_LOCATIONS,
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10771" title="HCK-10771" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10771</a>  Support all directive locations to ensure the completeness of schema definitions - alpha 3
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added support of `FRAGMENT_DEFINITION`, `FRAGMENT_SPREAD `, `INLINE_FRAGMENT `, `VARIABLE_DEFINITION ` directive locations for FE and RE

...

