### PR TITLE
HCK-10963: add backward compatibility with old version of connection config

### DIFF
--- a/reverse_engineering/helpers/fetchIntrospectionSchema.js
+++ b/reverse_engineering/helpers/fetchIntrospectionSchema.js
@@ -75,7 +75,10 @@ async function fetchIntrospectionSchema({ connectionInfo }) {
 		headers: buildRequestHeaders(connectionInfo),
 		body: JSON.stringify({ query: getIntrospectionQuery() }),
 	};
-	const response = await hckFetch(connectionInfo.url, options);
+
+	// If the URL is not provided, use the host keyword for backward compatibility with the less than 8.1.4 app version
+	const url = connectionInfo.url || connectionInfo.host;
+	const response = await hckFetch(url, options);
 	return await parseResponse(response);
 }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10963" title="HCK-10963" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10963</a>  GraphQL endpoint lost for saved Connections
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

- Add an additional check to use the old `host` keyword for GraphQL server endpoint when the `url` keyword not exist in connection 

...