### PR TITLE
Bring back re.js api entrypoint for browser

### DIFF
--- a/api/re.js
+++ b/api/re.js
@@ -1,0 +1,1 @@
+module.exports = require('../reverse_engineering/api');

--- a/esbuild.package.js
+++ b/esbuild.package.js
@@ -12,13 +12,14 @@ esbuild
 	.build({
 		entryPoints: [
 			path.resolve(__dirname, 'api', 'fe.js'),
+			path.resolve(__dirname, 'api', 're.js'),
 			path.resolve(__dirname, 'forward_engineering', 'api.js'),
 			path.resolve(__dirname, 'reverse_engineering', 'api.js'),
 		],
 		bundle: true,
 		keepNames: true,
 		platform: 'node',
-		target: 'node16',
+		target: 'node22',
 		outdir: RELEASE_FOLDER_PATH,
 		minify: true,
 		logLevel: 'info',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "GraphQL",
-	"version": "0.2.3",
+	"version": "0.2.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "GraphQL",
-			"version": "0.2.3",
+			"version": "0.2.7",
 			"hasInstallScript": true,
 			"dependencies": {
-				"@hackolade/fetch": "1.1.1",
+				"@hackolade/fetch": "1.3.0",
 				"graphql": "16.10.0"
 			},
 			"devDependencies": {
@@ -631,9 +631,9 @@
 			}
 		},
 		"node_modules/@hackolade/fetch": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@hackolade/fetch/-/fetch-1.1.1.tgz",
-			"integrity": "sha512-3KQhDuLfe16MtIGnqHBGxSh7gKtzpb5f/fGgwkMpJx6SeZD9S3CVHTQyXJ6oiskA8kG1+EdRSpRsnfplfuvxfw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@hackolade/fetch/-/fetch-1.3.0.tgz",
+			"integrity": "sha512-c148fu1kccwRxmLJ2UoW0EZyXU2gHSuCc6iT2LYYfa78ZNIsvAE/QVh3+CWyianhQL/vmivfUXvRHBFLPWXTJA==",
 			"license": "MIT",
 			"dependencies": {
 				"@smithy/fetch-http-handler": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "description": "Hackolade plugin for GraphQL",
     "disabled": false,
     "dependencies": {
-        "@hackolade/fetch": "1.1.1",
+        "@hackolade/fetch": "1.3.0",
         "graphql": "16.10.0"
     },
     "lint-staged": {


### PR DESCRIPTION
## Content

- Bring back re.js to enable RE from browser
- Fixes the circular dependency on electron when building GraphQL plugin entrypoints for browser

## Technical details

- Uses the newer 1.3.0 release of @hackolade/fetch

HCK-10959