### PR TITLE
Externalize @hackolade/fetch in esbuild.package.js to let studio decide which entrypoint to use from the lib

### DIFF
--- a/esbuild.package.js
+++ b/esbuild.package.js
@@ -23,7 +23,7 @@ esbuild
 		outdir: RELEASE_FOLDER_PATH,
 		minify: true,
 		logLevel: 'info',
-		external: ['electron'],
+		external: ['electron', '@hackolade/fetch'],
 		plugins: [
 			clean({
 				patterns: [DEFAULT_RELEASE_FOLDER_PATH],


### PR DESCRIPTION
HCK-10959