### PR TITLE
HCK-11251: improved escaping logic to prevent last ip portion being confused with port

### DIFF
--- a/reverse_engineering/helpers/escapeV6IpForURL.js
+++ b/reverse_engineering/helpers/escapeV6IpForURL.js
@@ -16,13 +16,13 @@ const ip = require('ip');
  */
 function escapeV6IpForURL({ host }) {
 	/**
-	 * If the host is already URL compatible then the ip lib will return false > ip.isV6Format('[::1]') false If the host
-	 * is a proper ipv6 ip then the `new URL(host)` will fail with Uncaught TypeError: Invalid URL code:
-	 * 'ERR_INVALID_URL', !ip.isV4Format(host) check required because isV6Format returns true for ipv4 address because of
-	 * backward compatibility
+	 * If the host is already URL compatible then the ip lib will return false > ip.isV6Format('[::1]') false If the
+	 * host is a proper ipv6 ip then the `new URL(host)` will fail with Uncaught TypeError: Invalid URL code:
+	 * 'ERR_INVALID_URL', !ip.isV4Format(host) check required because isV6Format returns true for ipv4 address because
+	 * of backward compatibility
 	 */
 	if (ip.isV6Format(host) && !ip.isV4Format(host)) {
-		return `[${host}]`;
+		return escapeHost(host);
 	}
 
 	const isUrlValid = isValidURL(host);
@@ -42,7 +42,20 @@ function escapeV6IpForURL({ host }) {
 	const port = separatedIpPortionsAndPort.at(-1);
 	const escapedIpWithPort = `[${ipPortions.join(':')}]:${port}`;
 
-	return host.replace(unescapedIpWithPort, escapedIpWithPort);
+	const hostWithEscapedAllPortionsButTheLastOne = host.replace(unescapedIpWithPort, escapedIpWithPort);
+	if (isValidURL(hostWithEscapedAllPortionsButTheLastOne)) {
+		return hostWithEscapedAllPortionsButTheLastOne;
+	}
+
+	return host.replace(unescapedIpWithPort, escapeHost(unescapedIpWithPort));
+}
+
+/**
+ * @param {string} host
+ * @returns {string}
+ */
+function escapeHost(host) {
+	return `[${host}]`;
 }
 
 /**


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11251" title="HCK-11251" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-11251</a>  Improve parsed ipv6 escaping logic to prevent mess up with port
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

 Improved escaping logic to prevent last ip portion being confused with port