### PR TITLE
HCK-11272: improve FE performance

### DIFF
--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -11,5 +11,7 @@
 		"model": false
 	},
 	"mode": "graphqlschema",
-	"isApiSchema": false
+	"isApiSchema": false,
+	"disableJSONDataGeneration": true,
+	"disableAttributesSorting": true
 }

--- a/forward_engineering/mappers/fields.js
+++ b/forward_engineering/mappers/fields.js
@@ -85,7 +85,7 @@ function mapField({ name, fieldData, required, definitionsIdToNameMap, addArgume
  */
 function getFieldType({ field, required }) {
 	if ('$ref' in field && field.$ref) {
-		const definitionName = getDefinitionNameFromReferencePath({ referencePath: field.$ref });
+		const definitionName = getDefinitionNameFromReferencePath({ referencePath: field.$ref }) || 'String';
 		return addRequired({ type: definitionName, required });
 	}
 

--- a/reverse_engineering/helpers/getDefinitionCategoryByNameMap.js
+++ b/reverse_engineering/helpers/getDefinitionCategoryByNameMap.js
@@ -20,14 +20,18 @@ const kindToDefinitionTypeName = {
  *
  * @param {object} options
  * @param {DefinitionNode[]} options.nodes - The nodes to search
+ * @param {string[]} options.rootTypeNames - The root type names to exclude
  * @returns {DefinitionNameToTypeNameMap} The found nodes with proper type
  */
-function getDefinitionCategoryByNameMap({ nodes }) {
+function getDefinitionCategoryByNameMap({ nodes, rootTypeNames }) {
 	return nodes
 		.filter(node => kindToDefinitionTypeName[node.kind])
 		.reduce((acc, node) => {
 			if ('name' in node && node.name !== undefined) {
-				acc[node.name.value] = kindToDefinitionTypeName[node.kind];
+				const isRootType = rootTypeNames.includes(node.name.value);
+				if (!isRootType) {
+					acc[node.name.value] = kindToDefinitionTypeName[node.kind];
+				}
 			}
 			return acc;
 		}, {});

--- a/reverse_engineering/mappers/schema.js
+++ b/reverse_engineering/mappers/schema.js
@@ -33,7 +33,7 @@ function getMappedSchema({ schemaItems, graphName, fieldsOrder }) {
 		container.schemaRootTypes?.rootSubscription || 'Subscription',
 	];
 
-	const definitionCategoryByNameMap = getDefinitionCategoryByNameMap({ nodes: schemaItems });
+	const definitionCategoryByNameMap = getDefinitionCategoryByNameMap({ nodes: schemaItems, rootTypeNames });
 
 	const rootTypeNodes = findNodesByKind({
 		nodes: schemaItems,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11272" title="HCK-11272" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-11272</a>  Github RE - FE Lower GraphQL schema tab endless spin - alpha 7 bis
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

The PR adds:
- New FE configs to disable fields sorting and JSON Data generation for FE script generation, to improve performance for large models.
- Adds fallback type for missing referenced definition. It covers the case when a root schema type is referenced by its field, which isn't currently supported.