### PR TITLE
HCK-12985: remove display option - "show only nullable attributes"

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,9 +72,6 @@
             "externalDefinitionsFromTargetSchema": true,
             "apiTarget": true,
             "FEScriptCommentsSupported": true,
-            "displayOptions": {
-                "hideNonNullableAttributes": true
-            },
             "openModelDefinitionsTabIfNoCollections": true,
             "erdDefinitions": {
                 "enabled": true,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12985" title="HCK-12985" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12985</a>  Remove the existing option "show only nullable attributes"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

You have no Jira task for this PR? Describe your changes here...

...

## Technical details

You feel the need to provide technical explanations? You can do it here...

...