### PR TITLE
HCK-13242: fix missed entity type

### DIFF
--- a/adapter/0.2.12.json
+++ b/adapter/0.2.12.json
@@ -1,0 +1,54 @@
+/**
+ * {
+ * 		"add": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"delete": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"modify": {
+ *	 		"entity": [
+ *	 			{
+ *					"from": { <properties that identify record> },
+ *					"to": { <properties that need to be changed> }
+ *				}
+ *			],
+ *			"container": [],
+ *			"model": [],
+ *			"view": [],
+ *			"field": []
+ * 		},
+ * }
+ *
+ * Set type to object if it is missing in entity definition
+ */
+{
+	"add": {},
+	"modify": {
+		"entity": [
+			[
+				"assignProperties",
+				{
+					"key": "type",
+					"exist": false
+				},
+				{
+					"type": "object"
+				}
+			]
+		]
+	},
+	"delete": {}
+}

--- a/reverse_engineering/mappers/schema.js
+++ b/reverse_engineering/mappers/schema.js
@@ -112,6 +112,7 @@ function getMappedSchemaFromInstance({ schemaItems, graphName, logger }) {
 					jsonSchema: {
 						properties,
 						required,
+						type: 'object',
 					},
 				},
 				emptyBucket: false,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-13242" title="HCK-13242" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-13242</a>  Fix RE from GraphQL instance
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

This PR introduces the following changes:
- Adds a missing entity `type` when performing reverse engineering from an instance.
- Adds an adapter to fix existing entities that were missing an entity `type`.